### PR TITLE
feat(deepgram): migrate STT streaming to SDK 3.x API

### DIFF
--- a/app/roleplaying/services/streaming_stt_manager.py
+++ b/app/roleplaying/services/streaming_stt_manager.py
@@ -1,17 +1,21 @@
 """
-스트리밍 STT 관리자
+스트리밍 STT 관리자 (Deepgram SDK 3.x)
 ===============================================
 
 역할:
-- Deepgram WebSocket 세션 관리
+- Deepgram WebSocket 세션 관리 (SDK 3.x API)
 - 실시간 부분 결과 수신
 - 세션 초기화/종료
+
+Deepgram SDK 3.x 변경사항:
+- listen.live() → listen.live.v1() (async context manager)
+- 모든 메서드가 async/await 기반
 """
 
 import asyncio
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, AsyncIterator, Dict, Optional
 
 from deepgram import DeepgramClient
 
@@ -23,46 +27,41 @@ __all__ = ["StreamingSTTSession", "StreamingSTTManager"]
 
 
 class StreamingSTTSession:
-    """Deepgram WebSocket 스트리밍 세션"""
+    """Deepgram WebSocket 스트리밍 세션 (SDK 3.x)"""
 
     def __init__(self, connection: Any):
         """
         Args:
-            connection: Deepgram WebSocket 연결
+            connection: Deepgram AsyncLiveConnection (SDK 3.x)
         """
         self.connection = connection
         self.transcript_buffer = ""
         self.is_finalized = False
 
     async def send_chunk(self, audio_chunk: bytes) -> None:
-        """오디오 청크 전송"""
+        """오디오 청크 전송 (비동기)"""
         try:
-            loop = asyncio.get_running_loop()
-            # ✅ 동기 send() 호출을 executor에서 실행 (블로킹 방지)
-            await loop.run_in_executor(
-                None,
-                self.connection.send,
-                audio_chunk
-            )
+            # ✅ SDK 3.x: send()는 이미 async
+            await self.connection.send(audio_chunk)
         except Exception as e:
             logger.error(f"Failed to send audio chunk: {e}", exc_info=True)
             raise
 
     async def receive_partial(self) -> Optional[str]:
-        """부분 인식 결과 수신"""
+        """부분 인식 결과 수신 (비동기)"""
         try:
-            loop = asyncio.get_running_loop()
-            # ✅ 동기 recv() 호출을 executor에서 실행 (블로킹 방지)
-            response = await loop.run_in_executor(
-                None,
-                self.connection.recv
-            )
+            # ✅ SDK 3.x: recv()는 이미 async
+            response = await self.connection.recv()
 
             if not response:
                 return None
 
             try:
-                data = json.loads(response)
+                # 응답이 문자열일 수도, dict일 수도 있음
+                if isinstance(response, str):
+                    data = json.loads(response)
+                else:
+                    data = response
 
                 # 부분 결과 추출
                 if "result" in data and "results" in data["result"]:
@@ -78,11 +77,14 @@ class StreamingSTTSession:
                 if data.get("is_final"):
                     self.is_finalized = True
 
-            except (json.JSONDecodeError, KeyError):
-                logger.debug("Could not parse streaming response")
+            except (json.JSONDecodeError, KeyError, TypeError) as e:
+                logger.debug(f"Could not parse streaming response: {e}")
 
             return None
 
+        except asyncio.TimeoutError:
+            logger.debug("Timeout waiting for streaming result")
+            return None
         except Exception as e:
             logger.error(f"Failed to receive streaming result: {e}", exc_info=True)
             raise
@@ -90,28 +92,39 @@ class StreamingSTTSession:
     async def finalize(self) -> str:
         """스트리밍 종료 및 최종 결과 반환"""
         try:
+            # ✅ SDK 3.x: finish()는 비동기
+            await self.connection.finish()
+
+            # 최종 결과 대기 (타임아웃 5초)
+            timeout = 5.0
             loop = asyncio.get_running_loop()
+            start_time = loop.time()
 
-            # ✅ 동기 finish() 호출을 executor에서 실행 (블로킹 방지)
-            await loop.run_in_executor(
-                None,
-                self.connection.finish
-            )
-
-            # 최종 결과 대기
             while not self.is_finalized:
                 try:
-                    # ✅ 동기 recv() 호출을 executor에서 실행 (블로킹 방지)
-                    response = await loop.run_in_executor(
-                        None,
-                        self.connection.recv
+                    elapsed = loop.time() - start_time
+                    if elapsed > timeout:
+                        logger.warning(f"Timeout waiting for finalized result after {timeout}s")
+                        break
+
+                    # ✅ SDK 3.x: recv()는 비동기
+                    response = await asyncio.wait_for(
+                        self.connection.recv(),
+                        timeout=timeout - elapsed
                     )
-                    data = json.loads(response)
+
+                    if isinstance(response, str):
+                        data = json.loads(response)
+                    else:
+                        data = response
 
                     if data.get("is_final"):
                         self.is_finalized = True
 
-                except (json.JSONDecodeError, StopIteration):
+                except asyncio.TimeoutError:
+                    logger.debug("Timeout waiting for final result")
+                    break
+                except (json.JSONDecodeError, StopIteration, TypeError):
                     break
 
             logger.info(f"STT finalized: {self.transcript_buffer}")
@@ -123,7 +136,7 @@ class StreamingSTTSession:
 
 
 class StreamingSTTManager:
-    """스트리밍 STT 세션 관리"""
+    """스트리밍 STT 세션 관리 (SDK 3.x)"""
 
     def __init__(self, client: Optional[DeepgramClient] = None):
         """
@@ -132,19 +145,29 @@ class StreamingSTTManager:
         """
         self.client = client or DeepgramClient(api_key=settings.deepgram_api_key)
         self._sessions: Dict[str, StreamingSTTSession] = {}
+        self._connections: Dict[str, Any] = {}  # 활성 WebSocket 연결 추적
 
-    def create_session(self, session_id: str) -> StreamingSTTSession:
+    async def create_session(self, session_id: str) -> StreamingSTTSession:
         """
-        스트리밍 세션 생성
+        스트리밍 세션 생성 (SDK 3.x: async context manager)
+
+        ✅ SDK 3.x 변경:
+        - listen.live() → listen.live.v1()
+        - 동기 → 비동기
+        - Context manager 사용
 
         Args:
             session_id: 세션 ID
 
         Returns:
             StreamingSTTSession
+
+        Raises:
+            Exception: 세션 생성 실패 시
         """
         try:
-            connection = self.client.listen.live(
+            # ✅ SDK 3.x: listen.live.v1()는 async context manager 반환
+            connection = await self.client.listen.live.v1(
                 model=settings.DEEPGRAM_MODEL,
                 language=settings.DEEPGRAM_LANGUAGE,
                 smart_format=settings.DEEPGRAM_SMART_FORMAT,
@@ -152,6 +175,9 @@ class StreamingSTTManager:
                 sample_rate=settings.DEEPGRAM_SAMPLE_RATE,
                 interim_results=settings.DEEPGRAM_INTERIM_RESULTS,
             )
+
+            # 연결 저장 (cleanup 시 필요)
+            self._connections[session_id] = connection
 
             session = StreamingSTTSession(connection)
             self._sessions[session_id] = session
@@ -183,6 +209,9 @@ class StreamingSTTManager:
             return None
 
         try:
+            # 오디오 전송
+            await session.send_chunk(chunk)
+            # 부분 결과 수신
             return await session.receive_partial()
         except Exception as e:
             logger.error(f"Chunk processing failed: {e}", exc_info=True)
@@ -199,6 +228,7 @@ class StreamingSTTManager:
             최종 인식 결과
         """
         session = self._sessions.pop(session_id, None)
+        connection = self._connections.pop(session_id, None)
 
         if not session:
             logger.warning(f"Session not found for finalization: {session_id}")
@@ -212,3 +242,28 @@ class StreamingSTTManager:
         except Exception as e:
             logger.error(f"Failed to finalize session {session_id}: {e}", exc_info=True)
             return ""
+
+        finally:
+            # 연결 정리
+            if connection:
+                try:
+                    await connection.aclose()
+                except Exception as e:
+                    logger.warning(f"Error closing connection: {e}")
+
+    async def cleanup(self, session_id: str) -> None:
+        """
+        세션 강제 정리 (비정상 종료 시)
+
+        Args:
+            session_id: 세션 ID
+        """
+        session = self._sessions.pop(session_id, None)
+        connection = self._connections.pop(session_id, None)
+
+        if connection:
+            try:
+                await connection.aclose()
+                logger.info(f"Connection closed: {session_id}")
+            except Exception as e:
+                logger.warning(f"Error closing connection: {e}")

--- a/app/roleplaying/services/stt_service.py
+++ b/app/roleplaying/services/stt_service.py
@@ -54,9 +54,11 @@ class STTService:
         logger.debug("Transcribing audio (%d bytes) via batch engine", len(audio_data))
         return await self.batch_engine.transcribe(audio_data)
 
-    def create_streaming_session(self, session_id: str) -> StreamingSTTSession:
+    async def create_streaming_session(self, session_id: str) -> StreamingSTTSession:
         """
-        스트리밍 STT 세션 생성
+        스트리밍 STT 세션 생성 (SDK 3.x: 비동기)
+
+        ✅ SDK 3.x 변경: create_session()이 비동기로 변경됨
 
         Args:
             session_id: 세션 ID
@@ -65,7 +67,7 @@ class STTService:
             StreamingSTTSession 객체
         """
         logger.debug(f"Creating streaming session: {session_id}")
-        return self.streaming_manager.create_session(session_id)
+        return await self.streaming_manager.create_session(session_id)
 
     async def process_chunk(
         self, session_id: str, audio_chunk: bytes
@@ -94,6 +96,19 @@ class STTService:
         """
         logger.debug(f"Finalizing streaming session: {session_id}")
         return await self.streaming_manager.finalize_session(session_id)
+
+    async def cleanup(self, session_id: str) -> None:
+        """
+        스트리밍 세션 강제 정리 (비정상 종료 시)
+
+        finalize_streaming()과 다르게, 최종 결과를 기다리지 않고 즉시 리소스를 정리합니다.
+        예상치 못한 클라이언트 연결 해제 시 사용하세요.
+
+        Args:
+            session_id: 스트리밍 세션 ID
+        """
+        logger.debug(f"Cleaning up streaming session: {session_id}")
+        await self.streaming_manager.cleanup(session_id)
 
 
 # 전역 STT 서비스 인스턴스

--- a/app/roleplaying/ws_realtime.py
+++ b/app/roleplaying/ws_realtime.py
@@ -274,10 +274,11 @@ async def _handle_init(
             expires_at=expires_at,
         )
 
-        # STT 스트리밍 세션 생성 (Deepgram WebSocket)
+        # STT 스트리밍 세션 생성 (Deepgram WebSocket, SDK 3.x)
         from app.roleplaying.services.stt_service import stt_service
         try:
-            stt_service.create_streaming_session(session_id)
+            # ✅ SDK 3.x: create_streaming_session()은 이제 비동기
+            await stt_service.create_streaming_session(session_id)
             logger.info(f"STT streaming session created: {session_id}")
         except Exception as e:
             logger.warning(f"Failed to create STT streaming session: {e}")
@@ -887,10 +888,12 @@ async def _send_error(
 async def _cleanup_session(session_id: str, reason: str) -> None:
     """세션 정리 (연결 끊김 또는 에러 시)"""
     try:
-        # STT 스트리밍 세션 정리
+        # STT 스트리밍 세션 강제 정리 (최종 결과 대기 없이)
         from app.roleplaying.services.stt_service import stt_service
         try:
-            await stt_service.finalize_streaming(session_id)
+            # ✅ cleanup() 사용: finalize_streaming()과 달리 최종 결과를 기다리지 않음
+            # 이는 예상치 못한 클라이언트 연결 해제 시 리소스 누수를 방지합니다
+            await stt_service.cleanup(session_id)
             logger.debug(f"STT streaming session cleaned up: {session_id}")
         except Exception as e:
             logger.debug(f"STT streaming cleanup failed (non-fatal): {e}")


### PR DESCRIPTION
## Summary
- Upgrade Deepgram SDK integration from 2.x to 3.x to fix `AttributeError: 'ListenClient' object has no attribute 'live'`
- Rewrite STT streaming to use SDK 3.x async native API instead of executor-based blocking calls
- Ensure all WebSocket handlers properly await async STT service methods
- Add robust resource cleanup on unexpected client disconnection

## Changes
### streaming_stt_manager.py (Core Migration)
- Change `listen.live()` → `listen.live.v1()` (SDK 3.x async context manager)
- Remove executor-based blocking calls (SDK 3.x methods are natively async)
- Make all methods async: `send_chunk()`, `receive_partial()`, `finalize()`
- Add proper timeout handling with `asyncio.wait_for()`
- Add connection cleanup methods for resource management

### stt_service.py (Facade Update)
- Make `create_streaming_session()` async
- Add `await` when calling streaming manager
- **Add new `cleanup()` method** for forcing resource cleanup on unexpected disconnection
  - Unlike `finalize_streaming()`, doesn't wait for final transcription result
  - Essential for preventing resource leaks on abrupt client disconnection

### ws_realtime.py (WebSocket Handler)
- Add `await` to `stt_service.create_streaming_session()` call
- **Change `_cleanup_session()` to call `stt_service.cleanup()` instead of `finalize_streaming()`**
  - Ensures immediate resource release on connection termination
  - Prevents potential hanging when waiting for final transcription
  - Avoids resource leaks on unexpected disconnects

## Test Plan
- [x] Verify no SDK 2.x API calls remain in codebase
- [x] Verify all Python files compile without syntax errors
- [x] Verify all async/await patterns are consistent
- [ ] Test WebSocket connection with audio streaming
- [ ] Verify STT partial results are received correctly
- [ ] Verify STT final results are returned on normal session finalization
- [ ] Test resource cleanup on unexpected client disconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)