### PR TITLE
feat: 시나리오 응답에 creationType 필드 추가

### DIFF
--- a/app/roleplaying/schemas.py
+++ b/app/roleplaying/schemas.py
@@ -67,6 +67,7 @@ class ScenarioInfoDto(BaseModel):
     topicType: str = Field(..., description="토픽 타입 (overview, detail)")
     title: str = Field(..., max_length=200, description="시나리오 제목")
     fixedQuestions: List[str] = Field(..., min_items=3, max_items=3, description="고정 질문 목록 (3개)")
+    creationType: str = Field(..., description="시나리오 생성 방식 (prompt, slack)")
 
 
 class AnalysisResultDto(BaseModel):

--- a/app/roleplaying/services/prompt_based_generator_service.py
+++ b/app/roleplaying/services/prompt_based_generator_service.py
@@ -108,7 +108,8 @@ class PromptBasedScenarioService:
             aiRole=ai_role,
             topicType="direct",
             title=title,
-            fixedQuestions=fixed_questions
+            fixedQuestions=fixed_questions,
+            creationType="prompt"
         )
 
         logger.info(f"Successfully generated scenario for user {user_id}")

--- a/app/roleplaying/services/slack_scenario_service.py
+++ b/app/roleplaying/services/slack_scenario_service.py
@@ -187,7 +187,8 @@ class SlackScenarioService:
             aiRole=ai_role,
             topicType=topic_type,
             title=formatted_title,
-            fixedQuestions=questions
+            fixedQuestions=questions,
+            creationType="slack"
         )
 
     async def _build_conversation_summary(


### PR DESCRIPTION
## 요약

롤플레이 시나리오 생성 API 응답에 `creationType` 필드를 추가하여 시나리오가 **프롬프트 기반**인지 **Slack 분석 기반**인지 구분할 수 있도록 개선했습니다.

## 변경 사항

### 1. ScenarioInfoDto 스키마 수정
- `creationType` 필드 추가 (값: "prompt" 또는 "slack")
- API 응답에서 시나리오의 출처를 명확하게 표시

### 2. Prompt 기반 시나리오 생성
- `PromptBasedScenarioService`에서 시나리오 생성 시 `creationType="prompt"` 설정
- 사용자의 직접 입력으로 생성된 시나리오임을 표시

### 3. Slack 기반 시나리오 생성
- `SlackScenarioService`에서 시나리오 생성 시 `creationType="slack"` 설정
- Slack 대화 분석으로 생성된 시나리오임을 표시

## API 응답 예시

### Prompt 기반
\`\`\`json
{
  "scenario": {
    "aiRole": "Project Manager",
    "topicType": "direct",
    "title": "Project Timeline Discussion",
    "fixedQuestions": [...],
    "creationType": "prompt"
  }
}
\`\`\`

### Slack 기반
\`\`\`json
{
  "scenario": {
    "aiRole": "Tech Lead",
    "topicType": "overview",
    "title": "Technical Implementation Plan",
    "fixedQuestions": [...],
    "creationType": "slack"
  }
}
\`\`\`

## 이점

- 클라이언트에서 시나리오 출처를 쉽게 파악 가능
- UI/UX에서 시나리오 생성 방식에 따라 다른 표시 또는 처리 가능
- 데이터 분석 시 시나리오 생성 방식별 통계 수집 가능

## 테스트

- [x] 기존 Prompt 기반 API 동작 확인 (`/internal/scenarios/generate-from-prompt`)
- [x] 기존 Slack 기반 API 동작 확인 (`/internal/scenarios/analyze-conversation`)
- [x] 응답에 creationType 필드 포함 확인