### PR TITLE
feat: WebSocket을 통한 바이링궐 피드백 섹션 실시간 스트리밍 구현

### DIFF
--- a/app/integrations/clients/spring2_client.py
+++ b/app/integrations/clients/spring2_client.py
@@ -81,7 +81,6 @@ class Spring2Client:
         grammar_score: Optional[int] = None,
         relevance_score: Optional[int] = None,
         overall_score: Optional[int] = None,
-        feedback_text: Optional[str] = None,
         needs_correction: Optional[bool] = None,
         retry_count: Optional[int] = None,
         primary_issue: Optional[str] = None,
@@ -111,7 +110,6 @@ class Spring2Client:
             status: 세션 상태 (IN_PROGRESS, FINISHED, ERROR)
             pronunciation_score / grammar_score / relevance_score / overall_score:
                 피드백 점수 (없으면 None)
-            feedback_text: 피드백 메시지 (없으면 None)
             needs_correction: 재시도 필요 여부
             retry_count: 현재 재시도 횟수
             primary_issue: 피드백 이슈 분류 (pronunciation, grammar, relevance 등)
@@ -192,7 +190,6 @@ class Spring2Client:
                 grammar_score=grammar_score,
                 relevance_score=relevance_score,
                 overall_score=overall_score,
-                feedback_text=feedback_text,
                 needs_correction=needs_correction_int,  # ✅ Integer 0/1
                 retry_count=retry_count,
                 primary_issue=primary_issue,

--- a/app/roleplaying/handlers/_common.py
+++ b/app/roleplaying/handlers/_common.py
@@ -288,6 +288,8 @@ async def _send_feedback_messages(
 ) -> bool:
     """
     피드백 메시지 전송 및 재시도 여부 판단
+    - 점수 전송
+    - 피드백 섹션 스트리밍 (각 섹션이 생성되면 즉시 전송)
 
     Returns:
         True if retry needed (early return), False otherwise
@@ -296,7 +298,7 @@ async def _send_feedback_messages(
         logger.info(f"Skipping feedback processing: feedback_result is None")
         return False
 
-    # 점수 전송
+    # Step 1: 점수 전송
     scores = feedback_result.get("scores", {})
     feedback_msg = FeedbackMessage(
         pronunciation_score=scores.get("pronunciation_score"),
@@ -307,33 +309,39 @@ async def _send_feedback_messages(
     await websocket.send_json(feedback_msg.model_dump())
     logger.info(f"Feedback scores sent: {feedback_result['scores']}")
 
-    # ✅ 구조화된 피드백 섹션 전송 (NEW - 영문 + 한글)
+    # Step 2: ✅ 구조화된 피드백 섹션 스트리밍 (NEW - 각 섹션이 준비되면 즉시 전송)
     try:
-        feedback_sections = feedback_result.get("feedback_sections", [])
-        if feedback_sections:
-            from app.roleplaying.handlers.ws_message_models import FeedbackSectionsMessage
-            sections_msg = FeedbackSectionsMessage(sections=feedback_sections)
-            await websocket.send_json(sections_msg.model_dump())
-            logger.info(f"Feedback sections sent: {len(feedback_sections)} sections")
-    except Exception as e:
-        logger.error(f"Failed to send feedback sections: {e}")
+        from app.roleplaying.handlers.ws_message_models import FeedbackSectionsMessage
+        from app.roleplaying.services.feedback.feedback_service import feedback_orchestrator
 
-    # 피드백 텍스트 스트리밍 (선택사항 - 한글 피드백)
-    try:
-        feedback_text = feedback_result.get("feedback_text", "")
-        if feedback_text:
-            # '|'로 분할하고 각 부분을 별도로 전송
-            parts = feedback_text.split('|')
-            for part in parts:
-                part = part.strip()
-                if part:
-                    await websocket.send_json(
-                        FeedbackStreamingMessage(chunk=part).model_dump()
-                    )
-                    await asyncio.sleep(0.1)
-            logger.info(f"Feedback text streamed: {feedback_text[:60]}...")
+        # 평가 결과에서 필요한 정보 추출
+        pronunciation = feedback_result.get("pronunciation")
+        grammar = feedback_result.get("grammar")
+        relevance = feedback_result.get("relevance")
+        pronunciation_score = feedback_result.get("pronunciation_score")
+        grammar_score = feedback_result.get("grammar_score")
+        relevance_score = feedback_result.get("relevance_score")
+
+        # 피드백 섹션을 스트리밍으로 생성 및 전송
+        section_count = 0
+        async for section in feedback_orchestrator._build_feedback_sections_stream(
+            pronunciation=pronunciation,
+            grammar=grammar,
+            relevance=relevance,
+            pronunciation_score=pronunciation_score,
+            grammar_score=grammar_score,
+            relevance_score=relevance_score
+        ):
+            # 각 섹션이 완성되면 즉시 WebSocket으로 전송
+            sections_msg = FeedbackSectionsMessage(sections=[section])
+            await websocket.send_json(sections_msg.model_dump())
+            section_count += 1
+            logger.info(f"✅ [피드백 섹션 실시간 전송] {section['type']} ({section_count}/3)")
+
+        logger.info(f"All {section_count} feedback sections streamed")
+
     except Exception as e:
-        logger.error(f"Failed to send feedback text: {e}")
+        logger.error(f"Failed to stream feedback sections: {e}", exc_info=True)
 
     # 재시도 처리
     needs_correction = feedback_result.get("needs_correction", False)
@@ -408,11 +416,10 @@ async def _save_utterance_with_feedback(
                 "grammar_score": feedback_result["scores"].get("grammar_score"),
                 "relevance_score": feedback_result["scores"].get("relevance_score"),
                 "overall_score": feedback_result["scores"].get("overall_score"),
-                "feedback_text": feedback_result.get("feedback_text", ""),
                 "needs_correction": needs_correction,  # Boolean (변환은 spring2_client에서)
                 "retry_count": retry_count,
                 "primary_issue": feedback_result.get("primary_issue", "none"),
-                "feedback_sections": feedback_result.get("feedback_sections"),  # Option 3: 구조화된 피드백
+                "feedback_sections": feedback_result.get("feedback_sections"),  # 구조화된 피드백 (영문 + 한글)
             })
         else:
             # No feedback data - explicitly set fields
@@ -422,7 +429,6 @@ async def _save_utterance_with_feedback(
                 "grammar_score": None,
                 "relevance_score": None,
                 "overall_score": None,
-                "feedback_text": None,
                 "needs_correction": False,  # ✅ Boolean False (spring2_client에서 0으로 변환)
                 "retry_count": None,
                 "primary_issue": "none",  # ✅ 명시적으로 "none"

--- a/app/roleplaying/handlers/_common.py
+++ b/app/roleplaying/handlers/_common.py
@@ -307,7 +307,18 @@ async def _send_feedback_messages(
     await websocket.send_json(feedback_msg.model_dump())
     logger.info(f"Feedback scores sent: {feedback_result['scores']}")
 
-    # 피드백 텍스트 스트리밍
+    # ✅ 구조화된 피드백 섹션 전송 (NEW - 영문 + 한글)
+    try:
+        feedback_sections = feedback_result.get("feedback_sections", [])
+        if feedback_sections:
+            from app.roleplaying.handlers.ws_message_models import FeedbackSectionsMessage
+            sections_msg = FeedbackSectionsMessage(sections=feedback_sections)
+            await websocket.send_json(sections_msg.model_dump())
+            logger.info(f"Feedback sections sent: {len(feedback_sections)} sections")
+    except Exception as e:
+        logger.error(f"Failed to send feedback sections: {e}")
+
+    # 피드백 텍스트 스트리밍 (선택사항 - 한글 피드백)
     try:
         feedback_text = feedback_result.get("feedback_text", "")
         if feedback_text:

--- a/app/roleplaying/handlers/_common.py
+++ b/app/roleplaying/handlers/_common.py
@@ -26,7 +26,7 @@ from app.roleplaying.core.session_state_manager import session_manager
 from app.roleplaying.core.session_message_handler import SessionMessageHandler
 from app.roleplaying.handlers.ws_message_models import (
     AiTextMessage, AiTextStreamingMessage, AiTypingMessage,
-    ErrorMessage, FeedbackMessage, FeedbackStreamingMessage,
+    ErrorMessage, FeedbackMessage, FeedbackSectionsMessage, FeedbackStreamingMessage,
     RetryRequiredMessage, UtteranceSavedMessage
 )
 
@@ -311,8 +311,9 @@ async def _send_feedback_messages(
 
     # Step 2: ✅ 구조화된 피드백 섹션 스트리밍 (NEW - 각 섹션이 준비되면 즉시 전송)
     try:
-        from app.roleplaying.handlers.ws_message_models import FeedbackSectionsMessage
-        from app.roleplaying.services.feedback.feedback_service import feedback_orchestrator
+        from app.roleplaying.services.dependencies.feedback import get_feedback_orchestrator
+
+        feedback_orchestrator = get_feedback_orchestrator()
 
         # 평가 결과에서 필요한 정보 추출
         pronunciation = feedback_result.get("pronunciation")

--- a/app/roleplaying/handlers/ws_message_models.py
+++ b/app/roleplaying/handlers/ws_message_models.py
@@ -284,6 +284,66 @@ class FeedbackStreamingMessage(BaseModel):
     chunk: str = Field(..., description="피드백 텍스트 청크")
 
 
+class FeedbackSectionsMessage(BaseModel):
+    """
+    구조화된 피드백 섹션 메시지
+
+    발음, 문법, 맥락 각 항목별로 구조화된 피드백을 전송.
+    각 섹션은 type(항목명), feedback_en(영문 피드백), feedback_ko(한글 피드백), score(점수)를 포함.
+
+    예시:
+    {
+        "type": "FEEDBACK_SECTIONS",
+        "sections": [
+            {
+                "type": "pronunciation",
+                "feedback_en": "Your pronunciation is clear.",
+                "feedback_ko": "발음이 명확합니다.",
+                "score": 85
+            },
+            {
+                "type": "grammar",
+                "feedback_en": "Excellent grammar usage.",
+                "feedback_ko": "문법 사용이 뛰어납니다.",
+                "score": 90
+            },
+            {
+                "type": "relevance",
+                "feedback_en": "Your response is relevant.",
+                "feedback_ko": "응답이 주제에 적절합니다.",
+                "score": 88
+            }
+        ]
+    }
+    """
+
+    type: Literal["FEEDBACK_SECTIONS"] = "FEEDBACK_SECTIONS"
+    sections: List[dict] = Field(
+        ...,
+        description="각 항목별 피드백 섹션 (발음, 문법, 맥락)",
+        example=[
+            {
+                "type": "pronunciation",
+                "feedback_en": "Your pronunciation is clear.",
+                "feedback_ko": "발음이 명확합니다.",
+                "score": 85
+            },
+            {
+                "type": "grammar",
+                "feedback_en": "Excellent grammar usage.",
+                "feedback_ko": "문법 사용이 뛰어납니다.",
+                "score": 90
+            },
+            {
+                "type": "relevance",
+                "feedback_en": "Your response is relevant.",
+                "feedback_ko": "응답이 주제에 적절합니다.",
+                "score": 88
+            }
+        ]
+    )
+
+
 class RetryRequiredMessage(BaseModel):
     """
     재시도 요청 메시지
@@ -339,6 +399,7 @@ OutboundMessage = (
     | UtteranceSavedMessage
     | AiTypingMessage
     | FeedbackMessage
+    | FeedbackSectionsMessage
     | FeedbackStreamingMessage
     | RetryRequiredMessage
     | SessionEndedMessage

--- a/app/roleplaying/services/feedback/agent_tools.py
+++ b/app/roleplaying/services/feedback/agent_tools.py
@@ -95,6 +95,10 @@ async def evaluate_response_tool(
             "primary_issue": result.get("primary_issue", "none"),
             "feedback_sections": result.get("feedback_sections", []),
             "retry_count": result.get("retry_count", retry_count),
+            # 🔑 Raw evaluation objects for streaming feedback sections
+            "pronunciation": result.get("pronunciation"),
+            "grammar": result.get("grammar"),
+            "relevance": result.get("relevance"),
         }
 
     except Exception as e:

--- a/app/roleplaying/services/feedback/feedback_decision_agent.py
+++ b/app/roleplaying/services/feedback/feedback_decision_agent.py
@@ -198,6 +198,10 @@ class FeedbackDecisionAgentImpl:
                     "primary_issue": primary_issue,
                     "feedback_sections": evaluation_result.get("feedback_sections", []),
                     "retry_count": evaluation_result.get("retry_count", retry_count),
+                    # 🔑 Raw evaluation objects for streaming feedback sections
+                    "pronunciation": evaluation_result.get("pronunciation"),
+                    "grammar": evaluation_result.get("grammar"),
+                    "relevance": evaluation_result.get("relevance"),
                 }
 
             logger.info(

--- a/app/roleplaying/services/feedback/feedback_service.py
+++ b/app/roleplaying/services/feedback/feedback_service.py
@@ -100,10 +100,11 @@ class GrammarEvaluatorImpl:
 
             response = await self.llm.invoke(prompt)
             response_text = response if isinstance(response, str) else str(response)
-            logger.debug(f"🔍 [문법 평가 LLM 응답] {response_text[:200]}...")
+            logger.info(f"🔍 [문법 평가 LLM 응답] {response_text[:200]}...")
 
             # JSON 객체 추출 시도
             result = extract_json_from_response(response_text)
+            logger.info(f"📌 [JSON 추출 결과] {result}")  # ← 직접 추출 결과 로깅
             if result:
                 score = normalize_score(result.get("score"))
                 feedback = result.get("feedback", "")
@@ -111,10 +112,12 @@ class GrammarEvaluatorImpl:
                     logger.warning("Grammar evaluation returned no score")
                     return None
                 logger.info(f"✅ [문법 평가 완료] {score}점 | feedback: {feedback[:50] if feedback else '(없음)'}")
-                return {
+                return_value = {
                     "score": score,
                     "feedback": feedback
                 }
+                logger.info(f"📤 [문법 평가 반환값] {return_value}")  # ← 반환값 로깅
+                return return_value
             else:
                 # 점수만 추출 시도
                 score = normalize_score_from_string(response_text)
@@ -204,10 +207,11 @@ class RelevanceEvaluatorImpl:
 
             response = await self.llm.invoke(prompt)
             response_text = response if isinstance(response, str) else str(response)
-            logger.debug(f"🔍 [맥락 평가 LLM 응답] {response_text[:200]}...")
+            logger.info(f"🔍 [맥락 평가 LLM 응답] {response_text[:200]}...")
 
             # JSON 객체 추출 시도
             result = extract_json_from_response(response_text)
+            logger.info(f"📌 [JSON 추출 결과] {result}")  # ← 직접 추출 결과 로깅
             if result:
                 score = normalize_score(result.get("score"))
                 feedback = result.get("feedback", "")
@@ -215,10 +219,12 @@ class RelevanceEvaluatorImpl:
                     logger.warning("Relevance evaluation returned no score")
                     return None
                 logger.info(f"✅ [맥락 평가 완료] {score}점 | feedback: {feedback[:50] if feedback else '(없음)'}")
-                return {
+                return_value = {
                     "score": score,
                     "feedback": feedback
                 }
+                logger.info(f"📤 [맥락 평가 반환값] {return_value}")  # ← 반환값 로깅
+                return return_value
             else:
                 # 점수만 추출 시도
                 score = normalize_score_from_string(response_text)

--- a/app/roleplaying/services/feedback/feedback_service.py
+++ b/app/roleplaying/services/feedback/feedback_service.py
@@ -604,31 +604,13 @@ class FeedbackOrchestratorImpl:
                 retry_count
             )
 
-            # 피드백 텍스트 생성
-            feedback_start = time.time()
-            feedback_text = await self._generate_feedback_text(
-                user_text,
-                pronunciation,
-                grammar,
-                relevance,
-                needs_correction
-            )
-            feedback_time = time.time() - feedback_start
-            logger.info(f"💬 [피드백 텍스트 생성 완료] 소요 시간: {feedback_time:.2f}초")
 
             total_time = time.time() - start_time
             logger.info(f"🎉 [피드백 평가 전체 완료] 총 소요 시간: {total_time:.2f}초")
             logger.info(f"   종합 점수: {overall_score}점 | 교정 필요: {needs_correction}")
 
-            feedback_sections = await self._build_feedback_sections(
-                pronunciation,
-                grammar,
-                relevance,
-                pronunciation_score,
-                grammar_score,
-                relevance_score
-            )
-
+            # 피드백 섹션 스트리밍은 _common.py에서 별도로 처리
+            # 여기서는 점수와 교정 판단 정보만 반환
             return {
                 "needs_correction": needs_correction,
                 "primary_issue": primary_issue,
@@ -638,8 +620,12 @@ class FeedbackOrchestratorImpl:
                     "relevance_score": int(relevance_score) if relevance_score is not None else None,
                     "overall_score": int(overall_score) if overall_score is not None else None
                 },
-                "feedback_sections": feedback_sections,
-                "feedback_text": feedback_text,
+                "pronunciation": pronunciation,
+                "grammar": grammar,
+                "relevance": relevance,
+                "pronunciation_score": pronunciation_score,
+                "grammar_score": grammar_score,
+                "relevance_score": relevance_score,
                 "retry_count": retry_count
             }
 
@@ -705,7 +691,7 @@ class FeedbackOrchestratorImpl:
             logger.error(f"Feedback generation failed: {e}")
             return "평가를 완료했습니다."
 
-    async def _build_feedback_sections(
+    async def _build_feedback_sections_stream(
         self,
         pronunciation: Optional[Dict],
         grammar: Optional[Dict],
@@ -713,8 +699,12 @@ class FeedbackOrchestratorImpl:
         pronunciation_score: Optional[int],
         grammar_score: Optional[int],
         relevance_score: Optional[int],
-    ) -> List[Dict[str, Any]]:
-        """피드백 섹션(영문 + 한글) 구성 - 병렬 번역"""
+    ):
+        """
+        피드백 섹션(영문 + 한글) 스트리밍 생성
+
+        각 섹션의 번역이 완료되면 즉시 yield함 (실시간 스트리밍)
+        """
         # Step 1: 각 섹션의 영문 피드백 생성 (동기)
         section_en_data = [
             self._build_single_section(
@@ -737,28 +727,24 @@ class FeedbackOrchestratorImpl:
             ),
         ]
 
-        # Step 2: 병렬로 한글 번역 (LLM 호출 최소화)
+        # Step 2: 각 섹션을 순차적으로 번역하고 즉시 yield
         try:
-            translation_tasks = [
-                self._translate_feedback(section["feedback_en"])
-                for section in section_en_data
-            ]
-            korean_feedbacks = await asyncio.gather(*translation_tasks)
+            for section in section_en_data:
+                # 해당 섹션 번역 (한 번에 하나씩)
+                korean_feedback = await self._translate_feedback(section["feedback_en"])
+                section["feedback_ko"] = korean_feedback or section["feedback_en"]
 
-            # Step 3: 한글 번역 결과 병합
-            sections: List[Dict[str, Any]] = []
-            for i, section in enumerate(section_en_data):
-                section["feedback_ko"] = korean_feedbacks[i] or section["feedback_en"]  # 번역 실패 시 영문 사용
-                sections.append(section)
-
-            return sections
+                # 완성된 섹션 즉시 yield
+                yield section
+                logger.info(f"✅ [피드백 섹션 전송] {section['type']}: {section['feedback_en'][:40]}...")
 
         except Exception as e:
-            logger.error(f"Failed to translate feedback sections: {e}", exc_info=True)
-            # Fallback: 한글 번역 없이 영문만 반환 (기존 동작)
+            logger.error(f"Failed to stream feedback sections: {e}", exc_info=True)
+            # Fallback: 영문만으로 기존 섹션들 yield
             for section in section_en_data:
-                section["feedback_ko"] = section["feedback_en"]
-            return section_en_data
+                if not section.get("feedback_ko"):  # 아직 번역 안 된 섹션만
+                    section["feedback_ko"] = section["feedback_en"]
+                yield section
 
     async def _translate_feedback(self, feedback_en: str) -> Optional[str]:
         """LLM을 사용하여 영문 피드백을 한글로 번역"""

--- a/app/roleplaying/services/feedback/feedback_service.py
+++ b/app/roleplaying/services/feedback/feedback_service.py
@@ -511,6 +511,9 @@ class FeedbackOrchestratorImpl:
         self.feedback_judge = feedback_judge
         self.azure_tracker = azure_tracker
 
+        # 피드백 번역용 LLM (grammar_evaluator의 llm 사용)
+        self.llm = grammar_evaluator.llm if hasattr(grammar_evaluator, 'llm') else None
+
         logger.info("FeedbackOrchestratorImpl initialized")
 
     async def evaluate_response_fast(
@@ -617,7 +620,7 @@ class FeedbackOrchestratorImpl:
             logger.info(f"🎉 [피드백 평가 전체 완료] 총 소요 시간: {total_time:.2f}초")
             logger.info(f"   종합 점수: {overall_score}점 | 교정 필요: {needs_correction}")
 
-            feedback_sections = self._build_feedback_sections(
+            feedback_sections = await self._build_feedback_sections(
                 pronunciation,
                 grammar,
                 relevance,
@@ -702,7 +705,7 @@ class FeedbackOrchestratorImpl:
             logger.error(f"Feedback generation failed: {e}")
             return "평가를 완료했습니다."
 
-    def _build_feedback_sections(
+    async def _build_feedback_sections(
         self,
         pronunciation: Optional[Dict],
         grammar: Optional[Dict],
@@ -711,35 +714,82 @@ class FeedbackOrchestratorImpl:
         grammar_score: Optional[int],
         relevance_score: Optional[int],
     ) -> List[Dict[str, Any]]:
-        """피드백 섹션(영문) 구성"""
-        sections: List[Dict[str, Any]] = []
-
-        sections.append(
+        """피드백 섹션(영문 + 한글) 구성 - 병렬 번역"""
+        # Step 1: 각 섹션의 영문 피드백 생성 (동기)
+        section_en_data = [
             self._build_single_section(
                 section_type="pronunciation",
                 evaluation=pronunciation,
                 score=pronunciation_score,
                 fallback="Pronunciation feedback is unavailable."
-            )
-        )
-        sections.append(
+            ),
             self._build_single_section(
                 section_type="grammar",
                 evaluation=grammar,
                 score=grammar_score,
                 fallback="Grammar feedback is unavailable."
-            )
-        )
-        sections.append(
+            ),
             self._build_single_section(
                 section_type="relevance",
                 evaluation=relevance,
                 score=relevance_score,
                 fallback="Relevance feedback is unavailable."
-            )
-        )
+            ),
+        ]
 
-        return sections
+        # Step 2: 병렬로 한글 번역 (LLM 호출 최소화)
+        try:
+            translation_tasks = [
+                self._translate_feedback(section["feedback_en"])
+                for section in section_en_data
+            ]
+            korean_feedbacks = await asyncio.gather(*translation_tasks)
+
+            # Step 3: 한글 번역 결과 병합
+            sections: List[Dict[str, Any]] = []
+            for i, section in enumerate(section_en_data):
+                section["feedback_ko"] = korean_feedbacks[i] or section["feedback_en"]  # 번역 실패 시 영문 사용
+                sections.append(section)
+
+            return sections
+
+        except Exception as e:
+            logger.error(f"Failed to translate feedback sections: {e}", exc_info=True)
+            # Fallback: 한글 번역 없이 영문만 반환 (기존 동작)
+            for section in section_en_data:
+                section["feedback_ko"] = section["feedback_en"]
+            return section_en_data
+
+    async def _translate_feedback(self, feedback_en: str) -> Optional[str]:
+        """LLM을 사용하여 영문 피드백을 한글로 번역"""
+        try:
+            from app.roleplaying.prompts.constants import FEEDBACK_BILINGUAL_PROMPT
+
+            prompt = FEEDBACK_BILINGUAL_PROMPT.format(english_feedback=feedback_en)
+            response = await self.llm.invoke(prompt)
+
+            # JSON에서 korean_feedback 추출 시도
+            try:
+                json_match = re.search(r'\{[^{}]*"korean_feedback"[^{}]*\}', response, re.DOTALL)
+                if json_match:
+                    parsed = json.loads(json_match.group(0))
+                    korean_feedback = parsed.get("korean_feedback")
+                    if korean_feedback and korean_feedback.strip():
+                        logger.debug(f"✅ [번역 완료] {feedback_en[:30]}... → {korean_feedback[:30]}...")
+                        return korean_feedback
+            except Exception as e:
+                logger.warning(f"Failed to parse Korean feedback translation: {e}")
+
+            # JSON 파싱 실패 시 전체 응답 사용 (간단한 번역 결과일 수 있음)
+            if response and response.strip():
+                logger.debug(f"✅ [번역 완료 (파싱)] {feedback_en[:30]}... → {response[:30]}...")
+                return response.strip()
+
+            return None
+
+        except Exception as e:
+            logger.error(f"Feedback translation failed: {e}")
+            return None
 
     def _build_single_section(
         self,
@@ -748,7 +798,7 @@ class FeedbackOrchestratorImpl:
         score: Optional[int],
         fallback: str
     ) -> Dict[str, Any]:
-        """개별 섹션 포맷"""
+        """개별 섹션 포맷 (영문만 생성, 한글은 비동기로 추가)"""
         feedback_text = ""
         if evaluation and isinstance(evaluation, dict):
             feedback_text = evaluation.get("feedback") or ""
@@ -759,5 +809,6 @@ class FeedbackOrchestratorImpl:
         return {
             "type": section_type,
             "feedback_en": feedback_text,
+            "feedback_ko": "",  # 이후 async 메서드에서 채워짐
             "score": normalized_score,
         }

--- a/app/roleplaying/services/feedback/feedback_service.py
+++ b/app/roleplaying/services/feedback/feedback_service.py
@@ -100,18 +100,20 @@ class GrammarEvaluatorImpl:
 
             response = await self.llm.invoke(prompt)
             response_text = response if isinstance(response, str) else str(response)
+            logger.debug(f"🔍 [문법 평가 LLM 응답] {response_text[:200]}...")
 
             # JSON 객체 추출 시도
             result = extract_json_from_response(response_text)
             if result:
                 score = normalize_score(result.get("score"))
+                feedback = result.get("feedback", "")
                 if score is None:
                     logger.warning("Grammar evaluation returned no score")
                     return None
-                logger.info(f"✅ [문법 평가 완료] {score}점")
+                logger.info(f"✅ [문법 평가 완료] {score}점 | feedback: {feedback[:50] if feedback else '(없음)'}")
                 return {
                     "score": score,
-                    "feedback": result.get("feedback", "")
+                    "feedback": feedback
                 }
             else:
                 # 점수만 추출 시도
@@ -202,18 +204,20 @@ class RelevanceEvaluatorImpl:
 
             response = await self.llm.invoke(prompt)
             response_text = response if isinstance(response, str) else str(response)
+            logger.debug(f"🔍 [맥락 평가 LLM 응답] {response_text[:200]}...")
 
             # JSON 객체 추출 시도
             result = extract_json_from_response(response_text)
             if result:
                 score = normalize_score(result.get("score"))
+                feedback = result.get("feedback", "")
                 if score is None:
                     logger.warning("Relevance evaluation returned no score")
                     return None
-                logger.info(f"✅ [맥락 평가 완료] {score}점")
+                logger.info(f"✅ [맥락 평가 완료] {score}점 | feedback: {feedback[:50] if feedback else '(없음)'}")
                 return {
                     "score": score,
-                    "feedback": result.get("feedback", "")
+                    "feedback": feedback
                 }
             else:
                 # 점수만 추출 시도


### PR DESCRIPTION
## 요약

WebSocket을 통해 구조화된 바이링궐(영어 + 한글) 피드백 섹션을 실시간으로 스트리밍합니다. 사용자가 평가 완료 시점에 실시간으로 개별 피드백 섹션을 받을 수 있으며, LLM 기반 번역으로 정확한 한글 피드백을 제공합니다.

## 핵심 변경사항

### 1. WebSocket 메시지 구조 (`ws_message_models.py`)
- `FeedbackSectionsMessage` 클래스 추가
- 각 섹션: type(발음/문법/맥락), 바이링궐 피드백(영어+한글), 점수
- 번역 완료 시점에 개별 섹션 스트리밍

### 2. 피드백 서비스 (`feedback_service.py`)
- LLM 기반 비동기 번역 구현 (FEEDBACK_BILINGUAL_PROMPT 활용)
- `_build_feedback_sections_stream()` AsyncGenerator로 실시간 스트리밍
- 평가 객체(pronunciation, grammar, relevance)에서 원본 데이터 추출

### 3. ReAct Agent 파이프라인
- `evaluate_response_tool()`: 원본 평가 객체(pronunciation, grammar, relevance) 통과
- `FeedbackDecisionAgentImpl`: feedback_result에 이 객체들 포함
- 스트리밍 코드가 실제 피드백 텍스트에 접근 가능

### 4. Spring2 통합 (`spring2_client.py`)
- `save_utterance()`: feedback_text 파라미터 제거
- feedback_sections을 활용한 구조화된 피드백 처리

### 5. WebSocket 핸들러 (`_common.py`)
- Import 수정: 의존성 주입으로 `get_feedback_orchestrator()` 호출
- 스트리밍 루프: 섹션 완료 시마다 FeedbackSectionsMessage 전송
- 평가 실패 시 적절한 에러 처리 및 Fallback

## 테스트 계획

- [ ] 서버 시작 후 WebSocket 클라이언트 연결
- [ ] 음성 또는 텍스트로 사용자 발화 전송
- [ ] FEEDBACK_SECTIONS 메시지에 실제 피드백 텍스트 확인 ("unavailable" 아님)
- [ ] 섹션이 순서대로 스트리밍됨 (발음 → 문법 → 맥락)
- [ ] 영어와 한글 번역 모두 포함 확인
- [ ] 피드백 점수가 0-100 범위 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)