### PR TITLE
feat(chatbot): 프롬프트 개선 및 컨텍스트 기반 인터뷰 답변 기능 강화

### DIFF
--- a/app/it_explanation/api/chatbot_router.py
+++ b/app/it_explanation/api/chatbot_router.py
@@ -10,6 +10,7 @@ Endpoints:
 import httpx
 import logging
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
 
 from app.it_explanation.models.schemas import ChatbotMessage, ChatbotResponse
 from app.it_explanation.services.chatbot_service import ChatbotService
@@ -48,10 +49,7 @@ async def chat_with_bot(request: ChatbotMessage):
         # current_question을 dict로 변환
         current_question_dict = None
         if request.current_question:
-            current_question_dict = {
-                "question_text": request.current_question.question_text,
-                "question_text_ko": request.current_question.question_text_ko
-            }
+            current_question_dict = request.current_question.model_dump()
 
         # 챗봇 응답 생성
         response = await chatbot_service.get_response(
@@ -82,4 +80,69 @@ async def chat_with_bot(request: ChatbotMessage):
 
     except Exception as e:
         logger.error(f"Chatbot request failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.post("/chatbot/stream")
+async def chat_with_bot_stream(request: ChatbotMessage):
+    """
+    IT 용어 설명 챗봇 (스트리밍)
+
+    사용자의 질문에 대해 토큰 단위로 실시간 스트리밍 응답을 제공합니다.
+    대화 히스토리를 포함하면 컨텍스트 기반 응답을 받을 수 있습니다.
+
+    Args:
+        request: ChatbotMessage
+            - user_message: 사용자 질문
+            - conversation_history: 대화 히스토리 (선택)
+            - current_question: 현재 연습 중인 질문 컨텍스트 (선택)
+
+    Returns:
+        StreamingResponse: 토큰 단위 스트리밍 응답
+    """
+    try:
+        logger.info(f"💬 [API] POST /it-explanation/chatbot/stream")
+        logger.debug(f"User message: {request.user_message[:100]}...")
+        logger.debug(f"Request data - user_id: {request.user_id}, history: {len(request.conversation_history) if request.conversation_history else 0}, has_question: {request.current_question is not None}")
+
+        # current_question을 dict로 변환
+        current_question_dict = None
+        if request.current_question:
+            current_question_dict = request.current_question.model_dump()
+
+        # 스트리밍 생성기
+        async def generate_stream():
+            full_response = ""
+            try:
+                async for token in chatbot_service.get_response_stream(
+                    user_message=request.user_message,
+                    conversation_history=request.conversation_history,
+                    current_question=current_question_dict
+                ):
+                    full_response += token
+                    yield token
+
+                # 스트리밍 완료 후 Spring 2에 저장
+                try:
+                    await spring2_client.save_chatbot_conversation(
+                        user_id=request.user_id,
+                        user_message=request.user_message,
+                        bot_response=full_response,
+                        context=None
+                    )
+                    logger.info(f"✅ Saved streaming conversation to CRUD2")
+                except (httpx.RequestError, httpx.HTTPStatusError) as save_error:
+                    logger.error(f"⚠️ Failed to save streaming conversation to CRUD2: {save_error}")
+
+            except Exception as e:
+                logger.error(f"Chatbot streaming failed: {e}", exc_info=True)
+                yield "죄송합니다. 오류가 발생했습니다. 다시 시도해 주세요."
+
+        return StreamingResponse(
+            generate_stream(),
+            media_type="text/plain; charset=utf-8"
+        )
+
+    except Exception as e:
+        logger.error(f"Chatbot streaming request failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/app/it_explanation/api/chatbot_router.py
+++ b/app/it_explanation/api/chatbot_router.py
@@ -45,10 +45,19 @@ async def chat_with_bot(request: ChatbotMessage):
         logger.info(f"💬 [API] POST /it-explanation/chatbot")
         logger.debug(f"User message: {request.user_message[:100]}...")
 
+        # current_question을 dict로 변환
+        current_question_dict = None
+        if request.current_question:
+            current_question_dict = {
+                "question_text": request.current_question.question_text,
+                "question_text_ko": request.current_question.question_text_ko
+            }
+
         # 챗봇 응답 생성
         response = await chatbot_service.get_response(
             user_message=request.user_message,
-            conversation_history=request.conversation_history
+            conversation_history=request.conversation_history,
+            current_question=current_question_dict
         )
 
         # Spring 2에 대화 저장

--- a/app/it_explanation/models/schemas.py
+++ b/app/it_explanation/models/schemas.py
@@ -22,6 +22,12 @@ class PracticeSessionCreate(BaseModel):
     audio_url: Optional[str] = Field(None, description="음성 답변 S3 URL (선택)")
 
 
+class CurrentQuestionContext(BaseModel):
+    """현재 연습 중인 질문 컨텍스트"""
+    question_text: str = Field(..., description="질문 내용 (영문)")
+    question_text_ko: Optional[str] = Field(None, description="질문 내용 (한글)")
+
+
 class ChatbotMessage(BaseModel):
     """챗봇 메시지 요청"""
     user_id: int = Field(..., description="사용자 ID (Gateway에서 JWT로 추출)")
@@ -29,6 +35,10 @@ class ChatbotMessage(BaseModel):
     conversation_history: List[Dict[str, str]] = Field(
         default=[],
         description="대화 히스토리 [{'role': 'user', 'content': '...'}]"
+    )
+    current_question: Optional[CurrentQuestionContext] = Field(
+        None,
+        description="현재 연습 중인 질문 컨텍스트 (선택사항)"
     )
 
 

--- a/app/it_explanation/prompts/constants.py
+++ b/app/it_explanation/prompts/constants.py
@@ -82,37 +82,100 @@ IMPORTANT: The "feedback" field MUST be in Korean. Do not include any other text
 
 IT_CHATBOT_PROMPT = """You are a friendly Korean IT tutor helping learners prepare for English technical interviews.
 
+{question_context}
+
 Conversation History (last 5 turns):
 {conversation_history}
 
 User's Question: "{user_message}"
 
+Is this the user's FIRST question in this conversation? {is_first_question}
+
 Your Task:
-- **ALWAYS respond in Korean (한국어로 답변)**
-- Explain IT concepts in simple, clear Korean
-- **Keep explanation CONCISE: 2-3 sentences maximum for the main explanation**
-- Use ONE simple analogy if helpful
-- Provide ONE concrete example
-- **Include a "💡 핵심 영어 표현" section at the end with 5-6 key English terms**
+- **ALWAYS respond in Korean (한국어로 답변)** - Use natural, conversational Korean
+- Explain IT concepts clearly but keep it natural and friendly
+- Adapt your response based on conversation context
+- Reference previous discussion naturally (e.g., "아까 말한 클로저처럼...")
 - Be encouraging and patient
 
-Guidelines:
-1. Main explanation: 2-3 sentences only (핵심만 간결하게)
-2. Use "비유하자면" for ONE analogy
-3. Use "예를 들어" for ONE example
-4. Include important English terms in parentheses in the explanation
-5. End with "💡 핵심 영어 표현" section listing 5-6 key terms
-6. Format: "- term (한글 설명)"
+Response Format Rules:
 
-Example format:
-"REST API는 서버와 클라이언트(client)가 HTTP를 통해 데이터를 주고받는 규칙이에요. 비유하자면 레스토랑의 웨이터처럼, 손님 요청(request)을 주방에 전달하고 음식을 가져다주는 역할이죠.
+**IF this is the FIRST question ({is_first_question} == "true"):**
+1. Main explanation: 2-3 sentences (핵심만 간결하게)
+2. Use ONE simple analogy with "비유하자면"
+3. Provide ONE concrete code example with "예를 들어"
+4. Include important English terms naturally in parentheses
+5. End with "💡 핵심 영어 표현" section with **3-5 key terms only**
+
+Example (first question):
+"클로저(closure)는 함수가 자신이 만들어진 환경(environment)의 변수를 기억해서 계속 사용할 수 있는 기능이에요. 비유하자면 함수가 자신의 주변 환경을 작은 가방에 담아 언제든 꺼내 쓸 수 있는 거죠.
+
+예를 들어,
+```javascript
+function outer() {{
+  let count = 0;
+  return function inner() {{
+    count++;
+    return count;
+  }}
+}}
+```
 
 💡 핵심 영어 표현:
-- client (클라이언트)
-- server (서버)
-- GET request (조회 요청)
-- endpoint (API 주소)
-- response (응답)"
+- closure (클로저)
+- scope (스코프, 범위)
+- lexical environment (렉시컬 환경)"
 
-Respond naturally and helpfully in Korean. Keep it SHORT and CLEAR.
+**IF this is a FOLLOW-UP question ({is_first_question} == "false"):**
+1. **NO analogies, NO code examples** (이미 설명했으므로 반복 X)
+2. Direct, concise answer (1-2 sentences only)
+3. Only answer what was specifically asked
+4. Reference previous context naturally if relevant
+5. End with "💡 핵심 영어 표현" with **1-3 NEW terms only** (if relevant)
+6. If no new terms needed, skip the 💡 section entirely
+
+Example (follow-up question):
+User: "변수는 또 뭐야?"
+Response: "변수(variable)는 값을 담아두는 공간이에요. 아까 본 count처럼, 숫자나 문자 같은 데이터를 저장했다가 나중에 쓸 수 있죠.
+
+💡 핵심 영어 표현:
+- variable (변수)
+- value (값)"
+
+**Special Cases:**
+
+**IMPORTANT: When user asks for "모범 답안", "답변 추천", "위의 질문에 대한 답", "어떻게 답하면 돼?":**
+- They are asking about the MAIN INTERVIEW QUESTION in {question_context}, NOT about the chatbot conversation
+- Look at the question_context section above (the interview question the user is practicing)
+- Provide a MODEL ANSWER suitable for an ENGLISH job interview
+- **ANSWER IN ENGLISH** - The user is preparing for English technical interviews, so provide the actual interview answer in English
+- Format:
+  1. Brief Korean intro (1 sentence): "면접에서 이렇게 답하시면 좋을 것 같아요:"
+  2. **Full English answer** (3-4 sentences with real-world example)
+  3. Korean translation in parentheses after the English answer
+  4. End with 3-5 key English terms
+
+Example:
+User practicing: "What is a container?"
+User asks: "모범 답안 알려줘"
+Response: "면접에서 이렇게 답하시면 좋을 것 같아요:
+
+**English Answer:**
+\"A container is a lightweight, standalone package that includes everything needed to run an application—code, runtime, libraries, and dependencies. For example, using Docker, you can run an nginx web server with just `docker run nginx`, and it will work identically on any system. This eliminates the 'it works on my machine' problem and enables consistent deployments across development and production environments.\"
+
+(한글 의역: 컨테이너는 애플리케이션 실행에 필요한 모든 것을 포함한 독립적인 패키지예요. 예를 들어 도커로 nginx 서버를 어느 시스템에서나 동일하게 실행할 수 있죠. 개발/운영 환경 차이 문제를 해결하고 일관된 배포를 가능하게 해요.)
+
+💡 핵심 영어 표현:
+- container (컨테이너)
+- Docker (도커)
+- isolated environment (격리된 환경)
+- deployment (배포)"
+
+**Other guidelines:**
+- If user asks for clarification on previous chatbot explanation, reference it naturally
+- Keep conversational tone - avoid robotic repetition
+- Don't force English terms if they're not essential
+- When in doubt about which question they mean, assume they mean the MAIN interview question in question_context
+
+Respond naturally and helpfully in Korean. ADAPT your response length and detail to the conversation context.
 """

--- a/app/it_explanation/services/chatbot_service.py
+++ b/app/it_explanation/services/chatbot_service.py
@@ -55,7 +55,8 @@ class ChatbotService:
     async def get_response(
         self,
         user_message: str,
-        conversation_history: Optional[List[Dict[str, str]]] = None
+        conversation_history: Optional[List[Dict[str, str]]] = None,
+        current_question: Optional[Dict[str, str]] = None
     ) -> str:
         """
         챗봇 응답 생성
@@ -65,11 +66,16 @@ class ChatbotService:
             conversation_history: 대화 히스토리
                                  [{"role": "user", "content": "..."},
                                   {"role": "assistant", "content": "..."}]
+            current_question: 현재 연습 중인 질문 컨텍스트
+                            {"question_text": "...", "question_text_ko": "..."}
 
         Returns:
             챗봇 응답 텍스트
         """
         try:
+            # 첫 질문 여부 판단 (대화 히스토리가 없거나 비어있으면 첫 질문)
+            is_first_question = not conversation_history or len(conversation_history) == 0
+
             # 히스토리 포맷팅 (최근 5턴만, 총 10개 메시지)
             if conversation_history:
                 # 최근 10개 메시지만 유지
@@ -81,10 +87,33 @@ class ChatbotService:
             else:
                 history_text = "(No previous conversation)"
 
+            # 질문 컨텍스트 구성
+            question_context = ""
+            if current_question:
+                question_text = current_question.get("question_text", "")
+                question_text_ko = current_question.get("question_text_ko", "")
+                question_context = f"""
+============================================
+📝 MAIN INTERVIEW QUESTION (사용자가 연습 중인 면접 질문):
+============================================
+English: "{question_text}"
+Korean: "{question_text_ko}"
+
+⚠️ IMPORTANT:
+When the user asks "모범 답안", "답변 추천", "위의 질문에 대한 답", "어떻게 답하면 돼?",
+they are asking for a MODEL ANSWER to THIS MAIN INTERVIEW QUESTION above,
+NOT about the chatbot conversation topics (컨테이너, 라이브러리 등).
+
+Provide a professional answer suitable for a job interview (3-4 sentences, with example).
+============================================
+"""
+
             # 프롬프트 구성
             prompt = IT_CHATBOT_PROMPT.format(
+                question_context=question_context,
                 conversation_history=history_text,
-                user_message=user_message
+                user_message=user_message,
+                is_first_question="true" if is_first_question else "false"
             )
 
             logger.info("💬 [IT 챗봇] LLM 호출 중...")
@@ -108,7 +137,8 @@ class ChatbotService:
     async def get_response_stream(
         self,
         user_message: str,
-        conversation_history: Optional[List[Dict[str, str]]] = None
+        conversation_history: Optional[List[Dict[str, str]]] = None,
+        current_question: Optional[Dict[str, str]] = None
     ):
         """
         챗봇 응답 스트리밍 생성 (토큰 단위)
@@ -116,11 +146,15 @@ class ChatbotService:
         Args:
             user_message: 사용자 질문
             conversation_history: 대화 히스토리
+            current_question: 현재 연습 중인 질문 컨텍스트
 
         Yields:
             각 토큰 문자열
         """
         try:
+            # 첫 질문 여부 판단
+            is_first_question = not conversation_history or len(conversation_history) == 0
+
             # 히스토리 포맷팅
             if conversation_history:
                 history = conversation_history[-(self.max_history_turns * 2):]
@@ -131,10 +165,33 @@ class ChatbotService:
             else:
                 history_text = "(No previous conversation)"
 
+            # 질문 컨텍스트 구성
+            question_context = ""
+            if current_question:
+                question_text = current_question.get("question_text", "")
+                question_text_ko = current_question.get("question_text_ko", "")
+                question_context = f"""
+============================================
+📝 MAIN INTERVIEW QUESTION (사용자가 연습 중인 면접 질문):
+============================================
+English: "{question_text}"
+Korean: "{question_text_ko}"
+
+⚠️ IMPORTANT:
+When the user asks "모범 답안", "답변 추천", "위의 질문에 대한 답", "어떻게 답하면 돼?",
+they are asking for a MODEL ANSWER to THIS MAIN INTERVIEW QUESTION above,
+NOT about the chatbot conversation topics (컨테이너, 라이브러리 등).
+
+Provide a professional answer suitable for a job interview (3-4 sentences, with example).
+============================================
+"""
+
             # 프롬프트 구성
             prompt = IT_CHATBOT_PROMPT.format(
+                question_context=question_context,
                 conversation_history=history_text,
-                user_message=user_message
+                user_message=user_message,
+                is_first_question="true" if is_first_question else "false"
             )
 
             logger.info("💬 [IT 챗봇 스트리밍] LLM 스트리밍 중...")

--- a/app/it_explanation/services/question_service.py
+++ b/app/it_explanation/services/question_service.py
@@ -64,8 +64,14 @@ class QuestionService:
                     "key_keywords": data.get("key_keywords", []),
                     "model_answer": data.get("model_answer", "")
                 }
+        except httpx.RequestError as e:
+            logger.error(f"Failed to connect to Spring 2 for random question: {e}")
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to fetch random question from Spring 2 (HTTP error): {e}")
+            return None
         except Exception as e:
-            logger.error(f"Failed to fetch random question from Spring 2: {e}")
+            logger.error(f"An unexpected error occurred while fetching random question: {e}")
             return None
 
     async def get_question_by_id(self, question_id: int) -> Optional[Dict[str, Any]]:
@@ -102,6 +108,12 @@ class QuestionService:
                     "key_keywords": data.get("key_keywords", []),
                     "model_answer": data.get("model_answer", "")
                 }
+        except httpx.RequestError as e:
+            logger.error(f"Failed to connect to Spring 2 for question {question_id}: {e}")
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to fetch question {question_id} from Spring 2 (HTTP error): {e}")
+            return None
         except Exception as e:
-            logger.error(f"Failed to fetch question {question_id} from Spring 2: {e}")
+            logger.error(f"An unexpected error occurred while fetching question {question_id}: {e}")
             return None

--- a/app/it_explanation/services/question_service.py
+++ b/app/it_explanation/services/question_service.py
@@ -1,0 +1,107 @@
+"""
+Question Service
+================
+IT 질문 조회 서비스
+
+역할:
+- Spring 2 API를 통해 질문 조회
+"""
+
+import logging
+import json
+from typing import Optional, Dict, Any, List
+import httpx
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class QuestionService:
+    """IT 질문 조회 서비스"""
+
+    def __init__(self):
+        """질문 서비스 초기화"""
+        self.spring2_base_url = os.getenv("SPRING2_BASE_URL", "http://localhost:8081")
+        logger.info(f"QuestionService initialized (Spring2: {self.spring2_base_url})")
+
+    async def get_random_question(self) -> Optional[Dict[str, Any]]:
+        """
+        랜덤 질문 조회
+
+        Returns:
+            {
+                "question_id": int,
+                "question_text": str,
+                "question_text_ko": str,
+                "category": str,
+                "difficulty": str,
+                "key_keywords": list,
+                "model_answer": str
+            }
+            또는 None
+        """
+        try:
+            url = f"{self.spring2_base_url}/internal/it-questions/random"
+            logger.info(f"🎲 [랜덤 질문 조회] Spring 2 API 호출: {url}")
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url)
+
+                if response.status_code == 204:
+                    logger.warning("No questions available in database")
+                    return None
+
+                response.raise_for_status()
+                data = response.json()
+
+                # Spring 2가 이미 snake_case로 보냄 (@JsonProperty)
+                return {
+                    "question_id": data["question_id"],
+                    "question_text": data["question_text"],
+                    "question_text_ko": data.get("question_text_ko"),
+                    "category": data["category"],
+                    "difficulty": data["difficulty"],
+                    "key_keywords": data.get("key_keywords", []),
+                    "model_answer": data.get("model_answer", "")
+                }
+        except Exception as e:
+            logger.error(f"Failed to fetch random question from Spring 2: {e}")
+            return None
+
+    async def get_question_by_id(self, question_id: int) -> Optional[Dict[str, Any]]:
+        """
+        질문 ID로 조회
+
+        Args:
+            question_id: 질문 ID
+
+        Returns:
+            질문 데이터 또는 None
+        """
+        try:
+            url = f"{self.spring2_base_url}/internal/it-questions/{question_id}"
+            logger.info(f"🔍 [질문 조회] Spring 2 API 호출: {url}")
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url)
+
+                if response.status_code == 404:
+                    logger.warning(f"Question {question_id} not found")
+                    return None
+
+                response.raise_for_status()
+                data = response.json()
+
+                # Spring 2가 이미 snake_case로 보냄 (@JsonProperty)
+                return {
+                    "question_id": data["question_id"],
+                    "question_text": data["question_text"],
+                    "question_text_ko": data.get("question_text_ko"),
+                    "category": data["category"],
+                    "difficulty": data["difficulty"],
+                    "key_keywords": data.get("key_keywords", []),
+                    "model_answer": data.get("model_answer", "")
+                }
+        except Exception as e:
+            logger.error(f"Failed to fetch question {question_id} from Spring 2: {e}")
+            return None

--- a/app/it_explanation/services/session_service.py
+++ b/app/it_explanation/services/session_service.py
@@ -1,0 +1,149 @@
+"""
+Session Service
+================
+IT 연습 세션 저장 서비스
+
+역할:
+- Spring 2 API를 통해 세션 저장
+- 평가 결과를 MySQL에 영구 저장
+"""
+
+import logging
+from typing import Optional, Dict, Any
+import httpx
+import os
+
+logger = logging.getLogger(__name__)
+
+
+class SessionService:
+    """IT 연습 세션 저장 서비스"""
+
+    def __init__(self):
+        """세션 서비스 초기화"""
+        self.spring2_base_url = os.getenv("SPRING2_BASE_URL", "http://localhost:8081")
+        logger.info(f"SessionService initialized (Spring2: {self.spring2_base_url})")
+
+    async def create_session(
+        self,
+        user_id: int,
+        question_id: int,
+        user_answer: str,
+        clarity_score: int,
+        technical_accuracy_score: int,
+        terminology_score: int,
+        overall_score: int,
+        feedback_en: str,
+        feedback_ko: str = None,
+        session_type: str = "TEXT",
+        audio_url: str = None
+    ) -> Optional[int]:
+        """
+        세션 생성 및 저장
+
+        Args:
+            user_id: 사용자 ID
+            question_id: 질문 ID
+            user_answer: 사용자 답변
+            clarity_score: 명확성 점수
+            technical_accuracy_score: 기술적 정확성 점수
+            terminology_score: 전문용어 점수
+            overall_score: 종합 점수
+            feedback_en: 영문 피드백
+            feedback_ko: 한글 피드백 (선택)
+            session_type: TEXT or VOICE
+            audio_url: 음성 URL (선택)
+
+        Returns:
+            session_id 또는 None (실패 시)
+        """
+        try:
+            url = f"{self.spring2_base_url}/internal/it-practice/sessions"
+            logger.info(f"💾 [세션 저장] Spring 2 API 호출: {url}")
+
+            payload = {
+                "user_id": user_id,
+                "question_id": question_id,
+                "user_answer": user_answer,
+                "clarity_score": clarity_score,
+                "technical_accuracy_score": technical_accuracy_score,
+                "terminology_score": terminology_score,
+                "overall_score": overall_score,
+                "feedback_en": feedback_en,
+                "feedback_ko": feedback_ko,
+                "session_type": session_type,
+                "audio_url": audio_url
+            }
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(url, json=payload)
+
+                if response.status_code == 400:
+                    logger.error(f"Bad request when creating session: {response.text}")
+                    return None
+
+                response.raise_for_status()
+                data = response.json()
+
+                session_id = data.get("session_id")
+                logger.info(f"✅ [세션 저장 완료] session_id={session_id}")
+
+                return session_id
+
+        except Exception as e:
+            logger.error(f"Failed to create session: {e}", exc_info=True)
+            return None
+
+    async def get_user_sessions(self, user_id: int) -> Optional[list]:
+        """
+        사용자의 세션 목록 조회
+
+        Args:
+            user_id: 사용자 ID
+
+        Returns:
+            세션 목록 또는 None
+        """
+        try:
+            url = f"{self.spring2_base_url}/internal/it-practice/sessions/{user_id}"
+            logger.info(f"📋 [세션 목록 조회] Spring 2 API 호출: {url}")
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+
+                sessions = response.json()
+                logger.info(f"✅ [세션 목록 조회 완료] {len(sessions)}개 세션")
+
+                return sessions
+
+        except Exception as e:
+            logger.error(f"Failed to fetch user sessions: {e}")
+            return None
+
+    async def get_user_stats(self, user_id: int) -> Optional[Dict[str, Any]]:
+        """
+        사용자 통계 조회
+
+        Args:
+            user_id: 사용자 ID
+
+        Returns:
+            통계 정보 또는 None
+        """
+        try:
+            url = f"{self.spring2_base_url}/internal/it-practice/stats/{user_id}"
+            logger.info(f"📊 [통계 조회] Spring 2 API 호출: {url}")
+
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+
+                stats = response.json()
+                logger.info(f"✅ [통계 조회 완료]")
+
+                return stats
+
+        except Exception as e:
+            logger.error(f"Failed to fetch user stats: {e}")
+            return None

--- a/app/it_explanation/services/session_service.py
+++ b/app/it_explanation/services/session_service.py
@@ -90,8 +90,14 @@ class SessionService:
 
                 return session_id
 
+        except httpx.RequestError as e:
+            logger.error(f"Failed to connect to Spring 2 to create session: {e}", exc_info=True)
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to create session (HTTP error): {e}", exc_info=True)
+            return None
         except Exception as e:
-            logger.error(f"Failed to create session: {e}", exc_info=True)
+            logger.error(f"An unexpected error occurred while creating session: {e}", exc_info=True)
             return None
 
     async def get_user_sessions(self, user_id: int) -> Optional[list]:
@@ -117,8 +123,14 @@ class SessionService:
 
                 return sessions
 
+        except httpx.RequestError as e:
+            logger.error(f"Failed to connect to Spring 2 to fetch user sessions: {e}")
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to fetch user sessions (HTTP error): {e}")
+            return None
         except Exception as e:
-            logger.error(f"Failed to fetch user sessions: {e}")
+            logger.error(f"An unexpected error occurred while fetching user sessions: {e}")
             return None
 
     async def get_user_stats(self, user_id: int) -> Optional[Dict[str, Any]]:
@@ -144,6 +156,12 @@ class SessionService:
 
                 return stats
 
+        except httpx.RequestError as e:
+            logger.error(f"Failed to connect to Spring 2 to fetch user stats: {e}")
+            return None
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Failed to fetch user stats (HTTP error): {e}")
+            return None
         except Exception as e:
-            logger.error(f"Failed to fetch user stats: {e}")
+            logger.error(f"An unexpected error occurred while fetching user stats: {e}")
             return None


### PR DESCRIPTION
## 🧩 개요
IT 챗봇의 프롬프트와 컨텍스트 처리 로직을 개선하여,
	•	첫 질문/추가 질문에 따라 답변 형식을 다르게 하고
	•	“모범 답안”, “위의 질문” 요청 시 연습 중인 메인 면접 질문 기준으로 영어 인터뷰 답변을 생성하며
	•	current_question 컨텍스트를 통해 일관된 인터뷰 답변을 제공하도록 수정했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 문서 업데이트

### 상세 변경 사항
- `constants.py`의 IT_CHATBOT_PROMPT 개선  
  - 첫 질문 / 추가 질문 구분  
  - 모범 답안 요청 시 영어 답변 + 한국어 해석 규칙 추가  
- `chatbot_service.py`에 `current_question` 컨텍스트 처리 및 `is_first_question` 로직 반영  
- 스트리밍/일반 응답 모두 동일한 컨텍스트 구조로 프롬프트 구성  
- `schemas.py`에 `CurrentQuestionContext` 모델 추가 및 `ChatbotMessage`에 필드 통합  
- `chatbot_router.py`에서 `current_question`을 service로 전달하도록 수정  


## 🧪 테스트
	•	로컬에서 FastAPI 서버 실행 후 Swagger로 /it-explanation/chatbot 호출 테스트
	•	일반 질문 → 추가 질문 → “모범 답안”, “위의 질문에 대한 답” 순서로 대화 시나리오 검증
	•	current_question 전달 시 메인 면접 질문 기준으로 영어 모범 답안이 생성되는지 확인

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
