### PR TITLE
fix: deepgram stt version 관련 오류 수정

### DIFF
--- a/app/roleplaying/services/stt/batch_speech_to_text_engine.py
+++ b/app/roleplaying/services/stt/batch_speech_to_text_engine.py
@@ -12,7 +12,7 @@ import asyncio
 import logging
 from typing import Optional
 
-from deepgram import DeepgramClient
+from deepgram import DeepgramClient, PrerecordedOptions, BufferSource
 
 from app.config import settings
 from app.roleplaying.services.stt.audio_converter import AudioConverter
@@ -94,11 +94,19 @@ class BatchSTTEngine:
             인식된 텍스트
         """
         try:
-            response = self.client.listen.v1.media.transcribe_file(
-                request=wav_audio,
+            # Deepgram SDK 3.x API 사용
+            # BufferSource로 바이너리 데이터를 래핑
+            buffer_source = BufferSource(buffer=wav_audio)
+            
+            options = PrerecordedOptions(
                 model=settings.DEEPGRAM_MODEL,
                 language=settings.DEEPGRAM_LANGUAGE,
                 smart_format=settings.DEEPGRAM_SMART_FORMAT,
+            )
+            
+            response = self.client.listen.rest.v("1").transcribe_file(
+                source=buffer_source,
+                options=options
             )
 
             # 결과 추출


### PR DESCRIPTION
## 🧩 개요
마이크 버튼 클릭 시 발생하던 Deepgram STT API 호출 오류를 수정했습니다. Deepgram SDK 3.x의 올바른 API 경로와 파라미터 형식을 사용하도록 변경했습니다.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [x] `batch_speech_to_text_engine.py`: Deepgram SDK 3.x API 사용법 수정
  - `listen.v1.media.transcribe_file()` → `listen.rest.v("1").transcribe_file()` 변경
  - 바이너리 데이터를 `BufferSource`로 래핑하여 전달
  - 개별 파라미터를 `PrerecordedOptions` 객체로 통합

## 🧪 테스트
- 마이크 버튼 클릭 시 음성 인식이 정상 작동하는지 확인
- STT 결과가 올바르게 반환되는지 확인
- 오류 없이 음성 → 텍스트 변환이 완료되는지 확인

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
