### PR TITLE
feat: ElevenLabs tts 및 AI 질문 번역 수정

### DIFF
--- a/app/adapters/tts_adapter.py
+++ b/app/adapters/tts_adapter.py
@@ -19,6 +19,7 @@ class ElevenLabsTTSAdapter:
             raise ValueError("ELEVENLABS_API_KEY is not set")
         self.client = ElevenLabs(api_key=settings.ELEVENLABS_API_KEY)
         self.voice_id = settings.ELEVENLABS_VOICE_ID
+        self.model_id = settings.ELEVENLABS_MODEL_ID
     
     async def synthesize_with_viseme(
         self, 
@@ -34,10 +35,11 @@ class ElevenLabsTTSAdapter:
             }
         """
         try:
-            # ElevenLabs API 호출
+            # ElevenLabs API 호출 (저렴한 모델 사용)
             response = self.client.text_to_speech.convert_with_timestamps(
                 voice_id=self.voice_id,
-                text=text
+                text=text,
+                model_id=self.model_id
             )
             
             # Pydantic 모델이므로 model_dump()로 딕셔너리 변환 후 접근

--- a/app/config.py
+++ b/app/config.py
@@ -75,6 +75,7 @@ class Settings(BaseSettings):
     # ========================================
     ELEVENLABS_API_KEY: Optional[str] = Field(default=None, alias="ELEVENLABS_API_KEY")
     ELEVENLABS_VOICE_ID: str = Field("ErXwobaYiN019PkySvjV", alias="ELEVENLABS_VOICE_ID")  # Antoni (남자 목소리)
+    ELEVENLABS_MODEL_ID: str = Field("eleven_turbo_v2", alias="ELEVENLABS_MODEL_ID")  # Turbo v2 (0.5 credits/char, English only, fastest)
 
     # ========================================
     # Azure Speech (발음 평가)

--- a/app/integrations/clients/spring2_client.py
+++ b/app/integrations/clients/spring2_client.py
@@ -205,7 +205,13 @@ class Spring2Client:
             if recommended_keywords:
                 payload["recommended_keywords"] = recommended_keywords
 
-            logger.info(f"📤 [Spring2] Sending payload: {payload}")
+            # 로그용 payload 생성 (오디오 데이터 제외)
+            log_payload = payload.copy()
+            if "audio" in log_payload:
+                audio_len = len(log_payload["audio"]) if log_payload["audio"] else 0
+                log_payload["audio"] = f"<base64_audio_data:{audio_len}_bytes>" if audio_len > 0 else None
+            
+            logger.info(f"📤 [Spring2] Sending payload: {log_payload}")
 
             response = await client.post(url, json=payload)
 

--- a/app/roleplaying/handlers/_text_handler.py
+++ b/app/roleplaying/handlers/_text_handler.py
@@ -206,25 +206,28 @@ async def handle_user_text(router, websocket: WebSocket, session_id: str, messag
         ai_index = await SessionMessageHandler.increment_utterance_index_async(session_id)
         turn_number = session_state.get_ai_turn_number() if session_state else 1
 
-        try:
-            await _save_question_with_keywords(
-                session_id=session_id,
-                question_en=full_ai_response,
-                turn_number=turn_number,
-                utterance_index=ai_index,
-                user_role=session_state.my_role if session_state else "User",
-                ai_role=session_state.ai_role if session_state else "AI",
-                scenario_context=session_state.subject_id if session_state else "",
-                session_state=session_state,
-                slack_message=None,
-                is_fixed_question=is_fixed_question,
-                question_ko=full_ai_response_ko,
-            )
-        except Exception as e:
-            logger.error(f"Failed to save AI question: session={session_id}, error={e}", exc_info=True)
-            await websocket.send_json(
-                ErrorMessage(message="Failed to save AI question", code="AI_SAVE_ERROR").model_dump()
-            )
+        # ✅ Background task: Spring 2 저장 (응답 후 비동기 처리)
+        async def save_question_background():
+            try:
+                await _save_question_with_keywords(
+                    session_id=session_id,
+                    question_en=full_ai_response,
+                    turn_number=turn_number,
+                    utterance_index=ai_index,
+                    user_role=session_state.my_role if session_state else "User",
+                    ai_role=session_state.ai_role if session_state else "AI",
+                    scenario_context=session_state.subject_id if session_state else "",
+                    session_state=session_state,
+                    slack_message=None,
+                    is_fixed_question=is_fixed_question,
+                    question_ko=full_ai_response_ko,  # ✅ 이미 생성된 번역을 재사용 (중복 생성 방지)
+                )
+            except Exception as e:
+                logger.error(f"Background task - Failed to save AI question: session={session_id}, error={e}", exc_info=True)
+
+        # 백그라운드 태스크로 실행 (응답을 기다리지 않음)
+        save_task = asyncio.create_task(save_question_background())
+        save_task.add_done_callback(lambda task: _handle_task_error(task, "save_question_background"))
 
     except Exception as e:
         logger.error(f"User text handler error: {e}", exc_info=True)

--- a/app/roleplaying/handlers/_text_handler.py
+++ b/app/roleplaying/handlers/_text_handler.py
@@ -35,6 +35,7 @@ from app.roleplaying.handlers._common import (
 )
 from app.roleplaying.handlers.ws_message_models import (
     AiTypingMessage,
+    AiTextStreamingMessage,
     ErrorMessage,
     UtteranceSavedMessage,
     UserTextMessage,
@@ -205,28 +206,25 @@ async def handle_user_text(router, websocket: WebSocket, session_id: str, messag
         ai_index = await SessionMessageHandler.increment_utterance_index_async(session_id)
         turn_number = session_state.get_ai_turn_number() if session_state else 1
 
-        # ✅ Background task: Spring 2 저장 (응답 후 비동기 처리)
-        async def save_question_background():
-            try:
-                await _save_question_with_keywords(
-                    session_id=session_id,
-                    question_en=full_ai_response,
-                    turn_number=turn_number,
-                    utterance_index=ai_index,
-                    user_role=session_state.my_role if session_state else "User",
-                    ai_role=session_state.ai_role if session_state else "AI",
-                    scenario_context=session_state.subject_id if session_state else "",
-                    session_state=session_state,
-                    slack_message=None,
-                    is_fixed_question=is_fixed_question,
-                    question_ko=full_ai_response_ko,  # ✅ 이미 생성된 번역을 재사용 (중복 생성 방지)
-                )
-            except Exception as e:
-                logger.error(f"Background task - Failed to save AI question: session={session_id}, error={e}", exc_info=True)
-
-        # 백그라운드 태스크로 실행 (응답을 기다리지 않음)
-        save_task = asyncio.create_task(save_question_background())
-        save_task.add_done_callback(lambda task: _handle_task_error(task, "save_question_background"))
+        try:
+            await _save_question_with_keywords(
+                session_id=session_id,
+                question_en=full_ai_response,
+                turn_number=turn_number,
+                utterance_index=ai_index,
+                user_role=session_state.my_role if session_state else "User",
+                ai_role=session_state.ai_role if session_state else "AI",
+                scenario_context=session_state.subject_id if session_state else "",
+                session_state=session_state,
+                slack_message=None,
+                is_fixed_question=is_fixed_question,
+                question_ko=full_ai_response_ko,
+            )
+        except Exception as e:
+            logger.error(f"Failed to save AI question: session={session_id}, error={e}", exc_info=True)
+            await websocket.send_json(
+                ErrorMessage(message="Failed to save AI question", code="AI_SAVE_ERROR").model_dump()
+            )
 
     except Exception as e:
         logger.error(f"User text handler error: {e}", exc_info=True)

--- a/app/roleplaying/services/feedback/azure_speech_service.py
+++ b/app/roleplaying/services/feedback/azure_speech_service.py
@@ -22,11 +22,12 @@ from azure.cognitiveservices.speech import (
     SpeechConfig,
     SpeechRecognizer,
     PronunciationAssessmentConfig,
+    PronunciationAssessmentGradingSystem,
+    PronunciationAssessmentGranularity,
     ResultReason,
-    CancellationReason,
+    PropertyId,
 )
-from azure.cognitiveservices.speech.audio import AudioConfig
-import io
+from azure.cognitiveservices.speech.audio import AudioConfig, PushAudioInputStream
 
 from app.config import settings
 
@@ -150,8 +151,8 @@ class AzureSpeechService:
             평가 결과 딕셔너리
         """
         try:
-            # 오디오 데이터를 스트림으로 변환
-            audio_stream = io.BytesIO(audio_data)
+            # Azure Speech SDK용 Push 오디오 스트림 생성
+            audio_stream = PushAudioInputStream()
 
             # AudioConfig에 오디오 스트림 설정
             audio_config = AudioConfig(stream=audio_stream)
@@ -166,14 +167,23 @@ class AzureSpeechService:
             # Pronunciation Assessment 설정
             pronunciation_config = PronunciationAssessmentConfig(
                 reference_text=reference_text,
-                grading_system="HundredMark",
-                granularity="Phoneme",
+                grading_system=PronunciationAssessmentGradingSystem.HundredMark,
+                granularity=PronunciationAssessmentGranularity.Phoneme,
                 enable_miscue=True
             )
             pronunciation_config.apply_to(speech_recognizer)
 
+            # 오디오 데이터를 스트림에 작성 (recognize_once 호출 전)
+            audio_stream.write(audio_data)
+            audio_stream.close()
+
             # 발음 평가 실행
             result = speech_recognizer.recognize_once()
+
+            # 결과 상태 로깅
+            logger.error(f"Recognition result reason: {result.reason}")
+            logger.error(f"Recognition result text: {result.text if hasattr(result, 'text') else 'N/A'}")
+            logger.error(f"Result properties keys: {list(result.properties.keys()) if hasattr(result, 'properties') else 'N/A'}")
 
             # 결과 분석
             if result.reason == ResultReason.RecognizedSpeech:
@@ -218,10 +228,24 @@ class AzureSpeechService:
             정규화된 결과 딕셔너리
         """
         try:
-            # JSON 결과 파싱
-            pronunciation_result = json.loads(result.properties.get(
-                "SpeechServiceResponse_JsonResult"
-            ))
+            # JSON 결과 파싱 (PropertyId enum 사용)
+            json_result = result.properties.get(PropertyId.SpeechServiceResponse_JsonResult)
+
+            if not json_result:
+                available_props = list(result.properties.keys()) if hasattr(result, 'properties') else []
+                result_text = result.text if hasattr(result, 'text') else 'N/A'
+                logger.error(f"No JSON result in response. Result text: {result_text}")
+                logger.error(f"Available properties: {available_props}")
+                return {
+                    "success": False,
+                    "error_message": "No pronunciation assessment data in response",
+                    "debug_info": {
+                        "recognized_text": result_text,
+                        "available_properties": available_props
+                    }
+                }
+
+            pronunciation_result = json.loads(json_result)
 
             # 최상위 점수 추출
             nbest = pronunciation_result.get("NBest", [{}])[0]


### PR DESCRIPTION
## 🧩 개요
텍스트 핸들러에서 AI 질문 저장 시 한글 번역(question_ko) 누락 문제 수정. _generate_and_stream_ai_response 반환값 언패킹을 2개에서 3개로 수정하고, _save_question_with_keywords 호출 시 question_ko를 전달하도록 변경.

## 🔗 관련 이슈
Closes #

## 🌿 브랜치 정보
- 브랜치 이름: `feature/<이슈번호>-<작업내용>` 또는 `fix/<이슈번호>-<수정내용>`
- 기준 브랜치: `develop`

> 브랜치 이름 규칙이 맞지 않으면 리뷰 요청 전에 수정해주세요.

## ✅ 변경 사항
- [ ] _generate_and_stream_ai_response 반환값 언패킹 수정
기존: full_ai_response, is_fixed_question = await _generate_and_stream_ai_response(...)
수정: full_ai_response, is_fixed_question, full_ai_response_ko = await _generate_and_stream_ai_response(...)
- [ ] _save_question_with_keywords 호출 시 question_ko 파라미터 추가
question_ko=full_ai_response_ko 전달하여 한글 번역을 DB에 저장
- [ ] ElevenLabs config

## 🧪 테스트
텍스트 입력 모드로 롤플레잉 세션 시작
사용자 텍스트 입력 후 AI 응답 대기
두 번째 사용자 텍스트 입력 후 AI 응답 대기
DB 확인:
scenario_message 테이블에서 모든 AI 질문(speaker='ai')의 question_ko 필드 확인
두 번째 이후 질문도 question_ko가 정상 저장되었는지 확인

## 📸 참고 자료
(선택) 스크린샷, 로그 등

---

> 💡 **PR 생성 시 “Closes #이슈번호”를 포함하면**  
> 병합 시 해당 이슈가 자동으로 닫힙니다.
