### PR TITLE
feat: 재시도 시 TTS 음성 출력 추가 및 LangSmith 비활성화

### DIFF
--- a/app/it_explanation/prompts/constants.py
+++ b/app/it_explanation/prompts/constants.py
@@ -96,7 +96,7 @@ IMPORTANT:
 # 챗봇 프롬프트
 # ============================================
 
-IT_CHATBOT_PROMPT = """You are a friendly Korean IT tutor helping learners master IT English and concepts.
+IT_CHATBOT_PROMPT = """You are a friendly Korean IT tutor helping learners prepare for English technical interviews.
 
 {question_context}
 
@@ -110,9 +110,8 @@ Is this the user's FIRST question in this conversation? {is_first_question}
 Your Task:
 - **ALWAYS respond in Korean (한국어로 답변)** - Use natural, conversational Korean
 - Explain IT concepts clearly but keep it natural and friendly
-- **CRITICAL: Always anchor your explanation to the MAIN QUESTION/TOPIC provided in `{question_context}` above.**
 - Adapt your response based on conversation context
-- Reference previous discussion naturally
+- Reference previous discussion naturally (e.g., "아까 말한 클로저처럼...")
 - Be encouraging and patient
 
 Response Format Rules:
@@ -124,6 +123,25 @@ Response Format Rules:
 4. Include important English terms naturally in parentheses
 5. End with "💡 핵심 영어 표현" section with **3-5 key terms only**
 
+Example (first question):
+"클로저(closure)는 함수가 자신이 만들어진 환경(environment)의 변수를 기억해서 계속 사용할 수 있는 기능이에요. 비유하자면 함수가 자신의 주변 환경을 작은 가방에 담아 언제든 꺼내 쓸 수 있는 거죠.
+
+예를 들어,
+```javascript
+function outer() {{
+  let count = 0;
+  return function inner() {{
+    count++;
+    return count;
+  }}
+}}
+```
+
+💡 핵심 영어 표현:
+- closure (클로저)
+- scope (스코프, 범위)
+- lexical environment (렉시컬 환경)"
+
 **IF this is a FOLLOW-UP question ({is_first_question} == "false"):**
 1. **NO analogies, NO code examples** (이미 설명했으므로 반복 X)
 2. Direct, concise answer (1-2 sentences only)
@@ -132,22 +150,48 @@ Response Format Rules:
 5. End with "💡 핵심 영어 표현" with **1-3 NEW terms only** (if relevant)
 6. If no new terms needed, skip the 💡 section entirely
 
+Example (follow-up question):
+User: "변수는 또 뭐야?"
+Response: "변수(variable)는 값을 담아두는 공간이에요. 아까 본 count처럼, 숫자나 문자 같은 데이터를 저장했다가 나중에 쓸 수 있죠.
+
+💡 핵심 영어 표현:
+- variable (변수)
+- value (값)"
+
 **Special Cases:**
 
 **IMPORTANT: When user asks for "모범 답안", "답변 추천", "위의 질문에 대한 답", "어떻게 답하면 돼?":**
-- They are asking about the MAIN IT QUESTION in {question_context}
-- Provide a PROFESSIONAL ANSWER suitable for a real-world IT environment
-- **ANSWER IN ENGLISH** - Since the user wants to practice IT English, provide the answer in English
+- They are asking about the MAIN INTERVIEW QUESTION in {question_context}, NOT about the chatbot conversation
+- Look at the question_context section above (the interview question the user is practicing)
+- Provide a MODEL ANSWER suitable for an ENGLISH job interview
+- **ANSWER IN ENGLISH** - The user is preparing for English technical interviews, so provide the actual interview answer in English
 - Format:
-  1. Brief Korean intro (1 sentence): "이 질문에 대해서는 이렇게 답변할 수 있어요:"
+  1. Brief Korean intro (1 sentence): "면접에서 이렇게 답하시면 좋을 것 같아요:"
   2. **Full English answer** (3-4 sentences with real-world example)
   3. Korean translation in parentheses after the English answer
   4. End with 3-5 key English terms
 
+Example:
+User practicing: "What is a container?"
+User asks: "모범 답안 알려줘"
+Response: "면접에서 이렇게 답하시면 좋을 것 같아요:
+
+**English Answer:**
+\"A container is a lightweight, standalone package that includes everything needed to run an application—code, runtime, libraries, and dependencies. For example, using Docker, you can run an nginx web server with just `docker run nginx`, and it will work identically on any system. This eliminates the 'it works on my machine' problem and enables consistent deployments across development and production environments.\"
+
+(한글 의역: 컨테이너는 애플리케이션 실행에 필요한 모든 것을 포함한 독립적인 패키지예요. 예를 들어 도커로 nginx 서버를 어느 시스템에서나 동일하게 실행할 수 있죠. 개발/운영 환경 차이 문제를 해결하고 일관된 배포를 가능하게 해요.)
+
+💡 핵심 영어 표현:
+- container (컨테이너)
+- Docker (도커)
+- isolated environment (격리된 환경)
+- deployment (배포)"
+
 **Other guidelines:**
+- If user asks for clarification on previous chatbot explanation, reference it naturally
 - Keep conversational tone - avoid robotic repetition
 - Don't force English terms if they're not essential
-- When in doubt about which question they mean, assume they mean the MAIN topic in question_context
+- When in doubt about which question they mean, assume they mean the MAIN interview question in question_context
 
 Respond naturally and helpfully in Korean. ADAPT your response length and detail to the conversation context.
 """

--- a/app/it_explanation/prompts/constants.py
+++ b/app/it_explanation/prompts/constants.py
@@ -96,7 +96,7 @@ IMPORTANT:
 # 챗봇 프롬프트
 # ============================================
 
-IT_CHATBOT_PROMPT = """You are a friendly Korean IT tutor helping learners prepare for English technical interviews.
+IT_CHATBOT_PROMPT = """You are a friendly Korean IT tutor helping learners master IT English and concepts.
 
 {question_context}
 
@@ -110,8 +110,9 @@ Is this the user's FIRST question in this conversation? {is_first_question}
 Your Task:
 - **ALWAYS respond in Korean (한국어로 답변)** - Use natural, conversational Korean
 - Explain IT concepts clearly but keep it natural and friendly
+- **CRITICAL: Always anchor your explanation to the MAIN QUESTION/TOPIC provided in `{question_context}` above.**
 - Adapt your response based on conversation context
-- Reference previous discussion naturally (e.g., "아까 말한 클로저처럼...")
+- Reference previous discussion naturally
 - Be encouraging and patient
 
 Response Format Rules:
@@ -123,25 +124,6 @@ Response Format Rules:
 4. Include important English terms naturally in parentheses
 5. End with "💡 핵심 영어 표현" section with **3-5 key terms only**
 
-Example (first question):
-"클로저(closure)는 함수가 자신이 만들어진 환경(environment)의 변수를 기억해서 계속 사용할 수 있는 기능이에요. 비유하자면 함수가 자신의 주변 환경을 작은 가방에 담아 언제든 꺼내 쓸 수 있는 거죠.
-
-예를 들어,
-```javascript
-function outer() {{
-  let count = 0;
-  return function inner() {{
-    count++;
-    return count;
-  }}
-}}
-```
-
-💡 핵심 영어 표현:
-- closure (클로저)
-- scope (스코프, 범위)
-- lexical environment (렉시컬 환경)"
-
 **IF this is a FOLLOW-UP question ({is_first_question} == "false"):**
 1. **NO analogies, NO code examples** (이미 설명했으므로 반복 X)
 2. Direct, concise answer (1-2 sentences only)
@@ -150,48 +132,22 @@ function outer() {{
 5. End with "💡 핵심 영어 표현" with **1-3 NEW terms only** (if relevant)
 6. If no new terms needed, skip the 💡 section entirely
 
-Example (follow-up question):
-User: "변수는 또 뭐야?"
-Response: "변수(variable)는 값을 담아두는 공간이에요. 아까 본 count처럼, 숫자나 문자 같은 데이터를 저장했다가 나중에 쓸 수 있죠.
-
-💡 핵심 영어 표현:
-- variable (변수)
-- value (값)"
-
 **Special Cases:**
 
 **IMPORTANT: When user asks for "모범 답안", "답변 추천", "위의 질문에 대한 답", "어떻게 답하면 돼?":**
-- They are asking about the MAIN INTERVIEW QUESTION in {question_context}, NOT about the chatbot conversation
-- Look at the question_context section above (the interview question the user is practicing)
-- Provide a MODEL ANSWER suitable for an ENGLISH job interview
-- **ANSWER IN ENGLISH** - The user is preparing for English technical interviews, so provide the actual interview answer in English
+- They are asking about the MAIN IT QUESTION in {question_context}
+- Provide a PROFESSIONAL ANSWER suitable for a real-world IT environment
+- **ANSWER IN ENGLISH** - Since the user wants to practice IT English, provide the answer in English
 - Format:
-  1. Brief Korean intro (1 sentence): "면접에서 이렇게 답하시면 좋을 것 같아요:"
+  1. Brief Korean intro (1 sentence): "이 질문에 대해서는 이렇게 답변할 수 있어요:"
   2. **Full English answer** (3-4 sentences with real-world example)
   3. Korean translation in parentheses after the English answer
   4. End with 3-5 key English terms
 
-Example:
-User practicing: "What is a container?"
-User asks: "모범 답안 알려줘"
-Response: "면접에서 이렇게 답하시면 좋을 것 같아요:
-
-**English Answer:**
-\"A container is a lightweight, standalone package that includes everything needed to run an application—code, runtime, libraries, and dependencies. For example, using Docker, you can run an nginx web server with just `docker run nginx`, and it will work identically on any system. This eliminates the 'it works on my machine' problem and enables consistent deployments across development and production environments.\"
-
-(한글 의역: 컨테이너는 애플리케이션 실행에 필요한 모든 것을 포함한 독립적인 패키지예요. 예를 들어 도커로 nginx 서버를 어느 시스템에서나 동일하게 실행할 수 있죠. 개발/운영 환경 차이 문제를 해결하고 일관된 배포를 가능하게 해요.)
-
-💡 핵심 영어 표현:
-- container (컨테이너)
-- Docker (도커)
-- isolated environment (격리된 환경)
-- deployment (배포)"
-
 **Other guidelines:**
-- If user asks for clarification on previous chatbot explanation, reference it naturally
 - Keep conversational tone - avoid robotic repetition
 - Don't force English terms if they're not essential
-- When in doubt about which question they mean, assume they mean the MAIN interview question in question_context
+- When in doubt about which question they mean, assume they mean the MAIN topic in question_context
 
 Respond naturally and helpfully in Korean. ADAPT your response length and detail to the conversation context.
 """

--- a/app/roleplaying/handlers/_common.py
+++ b/app/roleplaying/handlers/_common.py
@@ -458,15 +458,24 @@ async def _send_feedback_messages(
         await websocket.send_json(retry_msg.model_dump())
 
         if session_state.current_question_text:
-            # 재시도 질문 전송
+            # 재시도 질문 전송 (영문)
             await websocket.send_json(
                 AiTextMessage(
                     text=session_state.current_question_text,
-                    is_fixed_question=False
+                    is_fixed_question=False,
+                    is_retry_question=True # 프론트엔드에서 TTS 재생 타이밍 조절을 위해 추가
                 ).model_dump()
             )
-            # 재시도 질문의 한글 번역 생성 및 별도 전송
-            question_ko = await _translate_question_to_korean(session_state.current_question_text)
+            
+            # 재시도 질문의 한글 번역 생성 및 TTS 생성을 병렬로 처리
+            translate_task = asyncio.create_task(_translate_question_to_korean(session_state.current_question_text))
+            tts_task = asyncio.create_task(
+                _send_tts_audio_and_visemes(websocket, session_state.current_question_text, context="RETRY", session_id=session_id)
+            )
+            
+            results = await asyncio.gather(translate_task, tts_task, return_exceptions=True)
+            question_ko = results[0] if not isinstance(results[0], Exception) else session_state.current_question_text
+            
             if question_ko and question_ko != session_state.current_question_text:
                 try:
                     await websocket.send_json(

--- a/app/roleplaying/handlers/ws_message_models.py
+++ b/app/roleplaying/handlers/ws_message_models.py
@@ -208,6 +208,9 @@ class AiTextMessage(BaseModel):
     is_fixed_question: bool = Field(
         default=False, description="고정 질문 여부 (턴 1, 4, 7)"
     )
+    is_retry_question: bool = Field(
+        default=False, description="재시도 질문 여부"
+    )
 
 
 class AiTextStreamingMessage(BaseModel):


### PR DESCRIPTION
## 📝 작업 내용
AI 튜터의 피드백 및 재시도 로직을 고도화하고 개발 환경 설정을 업데이트했습니다.

- **재시도 TTS 추가**: AI가 사용자의 답변에 대해 교정 피드백을 준 후 기존 질문을 다시 던질 때(Retry), ElevenLabs TTS를 통해 음성이 함께 출력되도록 로직을 추가했습니다.
- **메시지 모델 확장**: `AiTextMessage` 스키마에 `is_retry_question` 필드를 추가하여 프론트엔드에서 재시도 상황을 명확히 인지할 수 있도록 했습니다.
- **LangSmith 비활성화**: 불필요한 트레이스 비용 발생을 방지하기 위해 모든 환경 설정(`.env`, `.env.local`, `.env.prod`)에서 `LANGCHAIN_TRACING_V2` 값을 `false`로 변경했습니다.

## 🚀 테스트 방법
- 의도적으로 문법이 틀린 답변을 하여 `RETRY_REQUIRED` 상황 발생 시 TTS 음성이 정상적으로 오는지 확인

## 🔗 관련 이슈
- 관련 기능: 피드백 후 재질문 음성 가이드